### PR TITLE
Landmarks are not highlighted by default

### DIFF
--- a/src/components/Landmark.js
+++ b/src/components/Landmark.js
@@ -51,7 +51,7 @@ export class Landmarks {
         this.landmarksTooltip.activate();
         
         // turn off the highlights by default
-        this.visible = true;
+        this.visible = false;
         this.layer.setOpacity(0);
 
         this.handleToggle = this.handleToggle.bind(this);

--- a/src/components/Landmark.js
+++ b/src/components/Landmark.js
@@ -21,7 +21,7 @@ export function LandmarkInfo(features) {
 }
 
 const landmarkPaintProperty = {
-    "fill-opacity": 0.75,
+    "fill-opacity": 0, // turn off the highlights by default
     "fill-color": [
         "case",
         ["boolean", ["feature-state", "hover"], false],
@@ -48,11 +48,7 @@ export class Landmarks {
             addBelowLabels
         );
         this.landmarksTooltip = new Tooltip(this.layer, LandmarkInfo, 5);
-        this.landmarksTooltip.activate();
-        
-        // turn off the highlights by default
         this.visible = false;
-        this.layer.setOpacity(0);
 
         this.handleToggle = this.handleToggle.bind(this);
     }

--- a/src/components/Landmark.js
+++ b/src/components/Landmark.js
@@ -49,7 +49,10 @@ export class Landmarks {
         );
         this.landmarksTooltip = new Tooltip(this.layer, LandmarkInfo, 5);
         this.landmarksTooltip.activate();
+        
+        // turn off the highlights by default
         this.visible = true;
+        this.layer.setOpacity(0);
 
         this.handleToggle = this.handleToggle.bind(this);
     }


### PR DESCRIPTION
Unsure if this is the kosher way to do it but let me know!!!

this.visible = false; // this line unchecks the checkbox on the toolbar
this.layer.setOpacity(0); // this is the line that actually removes the highlight on the first load of the page. The better way would be to deactivate this layer instead of just setting its opacity to 0???