### PR TITLE
Don't show popup if About page is missing

### DIFF
--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -1,11 +1,19 @@
 import { html, render } from "lit-html";
 import { until } from "lit-html/directives/until";
 
-export function renderAboutModal({ place, unitsRecord }) {
+export function renderAboutModal({ place, unitsRecord }, userRequested) {
     const target = document.getElementById("modal");
     const template = until(
         fetch(`/assets/about/${place.id}/${unitsRecord.id}.html`)
-            .then(r => r.text())
+            .then((r) => {
+                if (r.status === 200) {
+                    return r.text();
+                } else if (userRequested) {
+                    return "No About Page exists for this project";
+                } else {
+                    throw new Error(response.statusText);
+                }
+            })
             .then(
                 content => html`
                     <div

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -34,8 +34,13 @@ export default function ToolsPlugin(editor) {
 
     // show about modal on startup by default
     // exceptions if you are on localhost or set 'dev' in URL
-    if (window.location.href.indexOf('dev') === -1) {
-        renderAboutModal(editor.state);
+    try {
+        if (window.location.href.indexOf('dev') === -1) {
+            renderAboutModal(editor.state);
+        }
+    } catch(e) {
+        // likely no About page exists - silently fail to console
+        console.error(e);
     }
 }
 
@@ -56,7 +61,7 @@ function getMenuItems(state) {
     let items = [
         {
             name: "About this module",
-            onClick: () => renderAboutModal(state)
+            onClick: () => renderAboutModal(state, true)
         },
         {
             name: "New plan",


### PR DESCRIPTION
This fixes a bug which we have on Mississippi and some other states.

If About text is missing, it will not automatically pop up on page load
If the user selects "About this module", we will show a custom error message (not technical 404)