### PR TITLE
Save current drawing progress

### DIFF
--- a/src/components/AboutSection.js
+++ b/src/components/AboutSection.js
@@ -1,6 +1,7 @@
 import { html } from "lit-html";
 import Parameter from "./Parameter";
 import Select from "./Select";
+import { savePlanToStorage } from "../routes";
 import { bindAll } from "../utils";
 
 export default class AboutSection {
@@ -44,6 +45,7 @@ export default class AboutSection {
             name: this.name,
             description: this.description
         });
+        savePlanToStorage(this.state.serialize());
         this.saved = true;
         this.renderCallback();
     }

--- a/src/models/State.js
+++ b/src/models/State.js
@@ -13,7 +13,7 @@ import { addBelowLabels, addBelowSymbols } from "../map/Layer";
 // "place" is mostly split up into these categories now.
 
 class DistrictingPlan {
-    constructor({ id, problem, idColumn, parts }) {
+    constructor({ id, problem, place, idColumn, parts }) {
         if (id) {
             this.id = id;
         } else {
@@ -22,6 +22,7 @@ class DistrictingPlan {
 
         this.problem = problem;
         this.assignment = {};
+        this.place = { id: place.id };
         this.parts = getParts(problem);
         if (parts) {
             for (let i = 0; i < parts.length; i++) {
@@ -53,7 +54,8 @@ class DistrictingPlan {
             id: this.id,
             idColumn: { key: this.idColumn.key, name: this.idColumn.name },
             problem: this.problem,
-            parts: this.parts.filter(p => p.visible).map(p => p.serialize())
+            parts: this.parts.filter(p => p.visible).map(p => p.serialize()),
+            place: { id: this.place.id }
         };
     }
 }
@@ -79,6 +81,7 @@ export default class State {
             id,
             assignment,
             problem,
+            place,
             ...args,
             idColumn: this.idColumn
         });

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -4,7 +4,7 @@ import InspectTool from "../components/Toolbar/InspectTool";
 import PanTool from "../components/Toolbar/PanTool";
 import Brush from "../map/Brush";
 import { renderAboutModal } from "../components/Modal";
-import { navigateTo } from "../routes";
+import { navigateTo, savePlanToStorage } from "../routes";
 import { download } from "../utils";
 
 export default function ToolsPlugin(editor) {
@@ -12,6 +12,9 @@ export default function ToolsPlugin(editor) {
     const brush = new Brush(state.units, 20, 0);
     brush.on("colorfeature", state.update);
     brush.on("colorend", state.render);
+    brush.on("colorend", () => {
+        savePlanToStorage(state.serialize());
+    });
 
     let tools = [
         new PanTool(),


### PR DESCRIPTION
Refreshing the page, returning to https://districtr.org/edit, etc. should remember your work in your browser

Use the browser's ```localStorage``` and no external DB / tracking

We currently use ```localStorage``` / ```savedState``` to remember information about the map which you last worked on (that's why you refresh and see the same city or state).  This uses the same code as "Export this plan" to also remember your drawn districts, communities, and community group names.  It updates whenever you paint, erase, and update groups.