### PR TITLE
Work in progress / for discussion: colorblindness color pallette

### DIFF
--- a/src/colors.js
+++ b/src/colors.js
@@ -6,12 +6,18 @@
  * one time.
  */
 let _colorScheme = [
-    "#0099cd",
-    "#ffca5d",
-    "#00cd99",
-    "#99cd00",
-    "#cd0099",
-    "#9900cd",
+    // http://mkweb.bcgsc.ca/colorblind/img/colorblindness.palettes.trivial.png
+    "#118CF8",
+    "#FCE027",
+    "#19A948",
+    "#0642BC",
+    "#F658F9",
+    "#98002E",
+    "#F66140",
+    "#6D008F",
+    "#1FCAD4",
+    "#92FE6F",
+    "#F8E1B1",
     // Color brewer:
     "#8dd3c7",
     "#bebada",


### PR DESCRIPTION
For review / consensus-building about our district colors. This will re-color community maps, but not districting plans.

http://mkweb.bcgsc.ca/colorblind/ recommends this color palette

![colorblindness palettes simple](https://user-images.githubusercontent.com/643918/64980377-b9bf0900-d887-11e9-8343-0a989b2676ac.png)

I wanted to have the first colors be similar to the current version. The colorblind-safe orange is more red, so I used a yellow instead.

![Screen Shot 2019-09-16 at 2 06 01 PM](https://user-images.githubusercontent.com/643918/64981964-2982c300-d88b-11e9-943f-ca7ab0f06e38.png)

With all of our other colors:

![Screen Shot 2019-09-16 at 2 06 26 PM](https://user-images.githubusercontent.com/643918/64981992-36071b80-d88b-11e9-8f2d-7be6e53d599b.png)

First 10 colors on gray MapBox background:

![Screen Shot 2019-09-16 at 1 59 32 PM](https://user-images.githubusercontent.com/643918/64981532-3d79f500-d88a-11e9-9b60-7b63d60d2410.png)
