### PR TITLE
User can make and edit landmarks

### DIFF
--- a/html/edit.html
+++ b/html/edit.html
@@ -17,6 +17,10 @@
         />
         <link
             rel="stylesheet"
+            href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.0.9/mapbox-gl-draw.css"
+            type="text/css"/>
+        <link
+            rel="stylesheet"
             href="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-geocoder/v4.2.0/mapbox-gl-geocoder.css"
             type="text/css"
         />
@@ -39,6 +43,7 @@
     <body>
         <main id="root"></main>
         <div id="modal"></div>
+        <script src="https://api.mapbox.com/mapbox-gl-js/plugins/mapbox-gl-draw/v1.0.9/mapbox-gl-draw.js"></script>
         <script src="/es6/edit.js"></script>
         <script>
             if (Object.assign === undefined || fetch === undefined) {

--- a/sass/_map.scss
+++ b/sass/_map.scss
@@ -27,6 +27,10 @@
     min-width: 16rem;
 }
 
+.mapbox-gl-draw_ctrl-draw-btn {
+    zoom: 1.2;
+}
+
 .overmapLogo {
     position: absolute;
     right: 25%;

--- a/src/components/Landmark.js
+++ b/src/components/Landmark.js
@@ -37,29 +37,124 @@ const landmarkPaintProperty = {
     ]
 };
 
+const landmarkCircleProperty = {
+    'circle-opacity': 0,
+    'circle-radius': 8,
+    'circle-color': [
+        "case",
+        ["boolean", ["feature-state", "hover"], false],
+        "#ff4f49",
+        "#e44944"
+    ]
+};
+
 export class Landmarks {
     constructor(map, landmarksRecord) {
+        this.landmarksRecord = landmarksRecord.source || landmarksRecord;
+        map.addSource("landmarklist", this.landmarksRecord);
         this.layer = new Layer(
             map,
             {
-                ...landmarksRecord,
-                paint: landmarkPaintProperty
+                id: "landmarks",
+                type: "fill",
+                source: "landmarklist",
+                paint: landmarkPaintProperty,
             },
             addBelowLabels
         );
+
+        this.points = {
+            type: 'geojson',
+            data: {
+                type: 'FeatureCollection',
+                features: this.landmarksRecord.data.features.filter(f =>
+                    f.geometry.type === 'Point')
+            }
+        };
+        map.addSource("landmarkpoints", this.points);
         this.landmarksTooltip = new Tooltip(this.layer, LandmarkInfo, 5);
+
+        this.markerlayer = new Layer(
+            map,
+            {
+                id: "landmarkpoints",
+                type: "circle",
+                source: "landmarkpoints",
+                paint: landmarkCircleProperty,
+            },
+            addBelowLabels
+        );
+        this.ptsTooltip = new Tooltip(this.markerlayer, LandmarkInfo, 5);
+
         this.visible = false;
 
+        this.drawTool = new MapboxDraw({
+            displayControlsDefault: false,
+            controls: {
+                point: true,
+                polygon: true,
+                //trash: true
+            }
+        });
+
+        this.layer.map.on('draw.create', (e) => {
+            let name = window.prompt('What is the name of this landmark?')
+            if (name) {
+                e.features.forEach((feature) => {
+                    feature.properties.name = name;
+                    this.drawTool.trash(feature.id);
+                    feature.id = Math.round(Math.random() * 1000000000);
+
+                    if (feature.geometry.type === "Point") {
+                        this.points.data.features.push(feature);
+                    }
+                    // a point is not rendered by the polygon layer
+                    // but we need to have it available for localStorage / export
+                    this.landmarksRecord.data.features.push(feature);
+                });
+
+                this.layer.map.getSource("landmarklist")
+                    .setData(this.landmarksRecord.data);
+                this.layer.map.getSource("landmarkpoints")
+                    .setData(this.points.data);
+            } else {
+                // cancel / remove landmark
+                e.features.forEach((feature) => {
+                    this.drawTool.trash(feature.id);
+                });
+            }
+        });
+        this.layer.map.on('draw.update', (e) => {
+            console.log(e.features);
+            console.log(e.action);
+            return false;
+        });
+
         this.handleToggle = this.handleToggle.bind(this);
+        this.handleDrawToggle = this.handleDrawToggle.bind(this);
     }
     handleToggle(checked) {
         this.visible = checked;
         if (checked) {
             this.layer.setOpacity(0.5);
             this.landmarksTooltip.activate();
+            this.markerlayer.setOpacity(0.5);
+            this.ptsTooltip.activate();
         } else {
             this.layer.setOpacity(0);
             this.landmarksTooltip.deactivate();
+            this.markerlayer.setOpacity(0);
+            this.ptsTooltip.deactivate();
+        }
+    }
+    handleDrawToggle(checked) {
+        if (checked) {
+            // makes no sense to draw without visible landmarks
+            this.layer.map.addControl(this.drawTool, "top-right");
+
+            this.handleToggle(true);
+        } else {
+            this.layer.map.removeControl(this.drawTool);
         }
     }
 }

--- a/src/components/Toolbar/LandmarkTool.js
+++ b/src/components/Toolbar/LandmarkTool.js
@@ -86,6 +86,9 @@ class LandmarkOptions {
     }
     render() {
         let properties = this.features.map(feature => feature.properties);
+        if (this.features.length && !this.selectFeature) {
+            this.selectFeature = 0;
+        }
 
         return html`
     <div class="ui-option">
@@ -100,7 +103,7 @@ class LandmarkOptions {
         <li class="option-list__item">
             ${properties.length > 1
                 ? Parameter({
-                      label: "Community:",
+                      label: "Edit:",
                       element: Select(
                           properties,
                           this.handleSelectFeature
@@ -110,12 +113,12 @@ class LandmarkOptions {
         </li>
     </ul>
 
-    ${this.features.length && LandmarkFormTemplate({
+    ${this.features.length ? LandmarkFormTemplate({
         name: properties[this.selectFeature].name,
         saved: false,
         onSave: this.onSave,
         setName: this.setName
-    })}
+    }) : "Add landmarks using the polygon and marker buttons on the top right of the map."}
         `;
     }
 }

--- a/src/components/Toolbar/LandmarkTool.js
+++ b/src/components/Toolbar/LandmarkTool.js
@@ -1,0 +1,47 @@
+import { html } from "lit-html";
+import { toggle } from "../Toggle";
+import { Landmarks } from "../Landmark";
+import Tool from "./Tool";
+
+export default class LandmarkTool extends Tool {
+    constructor(state) {
+        const icon = html`<i class="material-icons">label</i>`;
+        super("landmark", "Landmark", icon);
+
+        let lm = state.place.landmarks;
+        if (!lm.source && !lm.type) {
+            // we cannot replace the object, which is used to remember landmarks
+            lm.type = "geojson";
+            lm.data = {"type": "FeatureCollection", "features": []};
+        }
+        this.landmarks = new Landmarks(state.map, state.place.landmarks);
+        this.options = new LandmarkOptions(this.landmarks);
+    }
+    activate() {
+        super.activate();
+        this.landmarks.handleDrawToggle(true);
+    }
+    deactivate() {
+        super.deactivate();
+        this.landmarks.handleDrawToggle(false);
+    }
+}
+
+class LandmarkOptions {
+    constructor(landmarks) {
+        this.landmarks = landmarks;
+    }
+
+    render() {
+        return html`
+    <div class="ui-option">
+        <legend class="ui-label ui-label--row">Landmarks</legend>
+        ${toggle(
+            `Show landmarks`,
+            this.landmarks.visible,
+            this.landmarks.handleToggle
+        )}
+    </div>
+        `;
+    }
+}

--- a/src/components/Toolbar/LandmarkTool.js
+++ b/src/components/Toolbar/LandmarkTool.js
@@ -1,24 +1,53 @@
 import { html } from "lit-html";
 import { toggle } from "../Toggle";
+
+import { savePlanToStorage } from "../../routes";
+import { bindAll } from "../../utils";
 import { Landmarks } from "../Landmark";
 import Tool from "./Tool";
+import Parameter from "../Parameter";
+import Select from "../Select";
 
 export default class LandmarkTool extends Tool {
     constructor(state) {
         const icon = html`<i class="material-icons">label</i>`;
         super("landmark", "Landmark", icon);
 
+        this.state = state;
+        this.renderCallback = state.render;
+
+        bindAll(["updateLandmarkList", "updateFeatureName"], this);
+
         let lm = state.place.landmarks;
         if (!lm.source && !lm.type) {
+            // initialize a blank landmarks object
             // we cannot replace the object, which is used to remember landmarks
             lm.type = "geojson";
             lm.data = {"type": "FeatureCollection", "features": []};
         }
-        this.landmarks = new Landmarks(state.map, state.place.landmarks);
-        this.options = new LandmarkOptions(this.landmarks);
+        // compatibility with old landmarks
+        lm = lm.source || lm;
+
+        this.landmarks = new Landmarks(state.map, lm, this.updateLandmarkList);
+        this.options = new LandmarkOptions(
+            this.landmarks,
+            lm.data.features,
+            this.updateFeatureName,
+            this.renderCallback
+        );
+    }
+    updateLandmarkList() {
+        savePlanToStorage(this.state.serialize());
+        this.renderCallback();
+    }
+    updateFeatureName() {
+        this.landmarks.updateFeatures();
+        savePlanToStorage(this.state.serialize());
+        this.renderCallback();
     }
     activate() {
         super.activate();
+        // enable / disable drawing toolbar
         this.landmarks.handleDrawToggle(true);
     }
     deactivate() {
@@ -28,20 +57,101 @@ export default class LandmarkTool extends Tool {
 }
 
 class LandmarkOptions {
-    constructor(landmarks) {
-        this.landmarks = landmarks;
-    }
+    constructor(drawTool, features, updateFeatureName, renderCallback) {
+        this.drawTool = drawTool;
+        this.features = features;
+        this.updateFeatureName = updateFeatureName;
+        this.renderCallback = renderCallback;
 
+        bindAll(["handleSelectFeature", "onSave", "setName"], this);
+
+        this.selectFeature = this.features.length ? 0 : null;
+        this.updateName = this.features.length ? this.features[0].properties.name : null;
+    }
+    handleSelectFeature(e) {
+        this.selectFeature = e;
+        this.renderCallback();
+    }
+    setName(name) {
+        // remember but don't save to map and localStorage
+        this.updateName = name;
+    }
+    onSave() {
+        // commit updateName to map and localStorage
+        if (this.updateName !== null) {
+            this.features[this.selectFeature].properties.name = this.updateName;
+            this.updateFeatureName();
+            this.render();
+        }
+    }
     render() {
+        let properties = this.features.map(feature => feature.properties);
+
         return html`
     <div class="ui-option">
         <legend class="ui-label ui-label--row">Landmarks</legend>
         ${toggle(
-            `Show landmarks`,
-            this.landmarks.visible,
-            this.landmarks.handleToggle
+            "Show landmarks",
+            this.drawTool.visible,
+            this.drawTool.handleToggle
         )}
     </div>
+    <ul class="option-list">
+        <li class="option-list__item">
+            ${properties.length > 1
+                ? Parameter({
+                      label: "Community:",
+                      element: Select(
+                          properties,
+                          this.handleSelectFeature
+                      )
+                  })
+                : ""}
+        </li>
+    </ul>
+
+    ${this.features.length && LandmarkFormTemplate({
+        name: properties[this.selectFeature].name,
+        saved: false,
+        onSave: this.onSave,
+        setName: this.setName
+    })}
         `;
     }
+}
+
+
+function LandmarkFormTemplate({
+    name,
+    //description,
+    saved,
+    onSave,
+    setName,
+    //setDescription
+}) {
+    return html`
+        <ul class="option-list">
+            <li class="option-list__item">
+                <label class="ui-label">Name</label>
+                <input
+                    type="text"
+                    class="text-input"
+                    .value="${name}"
+                    @input=${e => setName(e.target.value)}
+                    @blur=${e => setName(e.target.value)}
+                />
+            </li>
+            <li class="option-list__item">
+                <button
+                    ?disabled=${saved}
+                    class="button button--submit button--${saved
+                        ? "disabled"
+                        : "alternate"} ui-label"
+                    @click=${onSave}
+                >
+                    ${saved ? "Saved" : "Save"}
+                </button>
+            </li>
+        </ul>
+    `;
 }

--- a/src/models/State.js
+++ b/src/models/State.js
@@ -22,7 +22,10 @@ class DistrictingPlan {
 
         this.problem = problem;
         this.assignment = {};
-        this.place = { id: place.id };
+        if (!place.landmarks) {
+            place.landmarks = {};
+        }
+        this.place = { id: place.id, landmarks: place.landmarks };
         this.parts = getParts(problem);
         if (parts) {
             for (let i = 0; i < parts.length; i++) {
@@ -55,7 +58,7 @@ class DistrictingPlan {
             idColumn: { key: this.idColumn.key, name: this.idColumn.name },
             problem: this.problem,
             parts: this.parts.filter(p => p.visible).map(p => p.serialize()),
-            place: { id: this.place.id }
+            place: { id: this.place.id, landmarks: this.place.landmarks }
         };
     }
 }

--- a/src/plugins/data-layers-plugin.js
+++ b/src/plugins/data-layers-plugin.js
@@ -1,4 +1,3 @@
-import { Landmarks } from "../components/Landmark";
 import { html } from "lit-html";
 import { toggle } from "../components/Toggle";
 import OverlayContainer from "../layers/OverlayContainer";
@@ -64,10 +63,6 @@ export function addCountyLayer(tab, state) {
 
 export default function DataLayersPlugin(editor) {
     const { state, toolbar } = editor;
-    const landmarks = state.place.landmarks
-        ? new Landmarks(state.map, state.place.landmarks)
-        : null;
-
     const tab = new LayerTab("layers", "Data Layers", editor.store);
 
     const districtsHeading =
@@ -88,19 +83,6 @@ export default function DataLayersPlugin(editor) {
             })}
         `
     );
-
-    if (landmarks) {
-        tab.addSection(
-            () => html`
-                <h4>Landmarks</h4>
-                ${toggle(
-                    `Show landmarks`,
-                    landmarks.visible,
-                    landmarks.handleToggle
-                )}
-            `
-        );
-    }
 
     if (state.place.state === state.place.name) {
         addCountyLayer(tab, state);

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -2,6 +2,7 @@ import BrushTool from "../components/Toolbar/BrushTool";
 import EraserTool from "../components/Toolbar/EraserTool";
 import InspectTool from "../components/Toolbar/InspectTool";
 import PanTool from "../components/Toolbar/PanTool";
+import LandmarkTool from "../components/Toolbar/LandmarkTool";
 import Brush from "../map/Brush";
 import { renderAboutModal } from "../components/Modal";
 import { navigateTo, savePlanToStorage } from "../routes";
@@ -26,7 +27,8 @@ export default function ToolsPlugin(editor) {
             state.nameColumn,
             state.unitsRecord,
             state.parts
-        )
+        ),
+        new LandmarkTool(state)
     ];
 
     for (let tool of tools) {

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -21,7 +21,7 @@ export default function ToolsPlugin(editor) {
         new PanTool(),
         new BrushTool(brush, state.parts),
         new EraserTool(brush),
-        new LandmarkTool(state),
+        (state.problem.type === "community" && new LandmarkTool(state)),
         new InspectTool(
             state.units,
             state.columnSets,
@@ -32,7 +32,9 @@ export default function ToolsPlugin(editor) {
     ];
 
     for (let tool of tools) {
-        toolbar.addTool(tool);
+        if (tool) {
+            toolbar.addTool(tool);
+        }
     }
     toolbar.selectTool("pan");
     toolbar.setMenuItems(getMenuItems(editor.state));

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -21,14 +21,14 @@ export default function ToolsPlugin(editor) {
         new PanTool(),
         new BrushTool(brush, state.parts),
         new EraserTool(brush),
+        new LandmarkTool(state),
         new InspectTool(
             state.units,
             state.columnSets,
             state.nameColumn,
             state.unitsRecord,
             state.parts
-        ),
-        new LandmarkTool(state)
+        )
     ];
 
     for (let tool of tools) {


### PR DESCRIPTION
## Features
- Adds landmarks to toolbar **edit: only in communities of interest**. (I'm proposing placing it between erase and inspect). It makes sense as a new tool, because you can't click on the map to draw a landmark while you are painting or erasing
- MapboxGL Draw widget (on top-right of map) will appear for you to draw a point or polygon
- After creating the landmark, you are prompted to name it (```window.prompt()``` for now)
- OK = saves the new landmark; Cancel = deletes the new landmark
- You can use the dropdown and form to rename any landmark

## Screenshots

![Screen Shot 2019-09-20 at 10 13 35 AM](https://user-images.githubusercontent.com/643918/65333913-5850b000-db8f-11e9-8aab-a3d1aff15c39.png)

![Screen Shot 2019-09-20 at 10 16 28 AM](https://user-images.githubusercontent.com/643918/65334091-be3d3780-db8f-11e9-9aa6-799847bb0c07.png)

## Compatibility
- Landmarks checkbox moves to this new tool section (communities only)
- Landmarks are saved to localStorage
- Compatible with existing landmark plans (Lowell and Chicago)

## Future stuff
We can use MapboxGL Draw and the form UI more, but this pull request is already huge.

The final flow would be: draw a landmark -> it's given a starter name (like New Polygon) -> you can drag the landmark, set name, and set description -> click ```Save``` -> it becomes a regular landmark where you can set name, set description, or delete.

**Once this is approved I will make a pull request from this branch to complete** ( https://github.com/mapmeld/districtr/tree/landmarks_p2 )