### PR TITLE
Communities of Interest can overlap

### DIFF
--- a/src/colors.js
+++ b/src/colors.js
@@ -75,7 +75,7 @@ const hoverColorScheme = colorScheme.map(hex =>
  * @param {string} hex
  * @param {number} lum
  */
-function changeColorLuminance(hex, lum) {
+export function changeColorLuminance(hex, lum) {
     // validate hex string
     hex = String(hex).replace(/[^0-9a-f]/gi, "");
     if (hex.length < 6) {
@@ -136,10 +136,17 @@ export function getUnitColorProperty(parts) {
         unitColorStyle
     ];
 
+    const blendWithHoverOption = [
+        "case",
+        ["boolean", ["feature-state", "hover"], false],
+        ["feature-state", "blendHoverColor"],
+        ["feature-state", "blendColor"]
+    ];
+
     const unitColorProperty = [
         "case",
         ["==", ["feature-state", "useBlendColor"], true],
-        ["feature-state", "blendColor"],
+        blendWithHoverOption,
         standardColor,
     ];
 

--- a/src/colors.js
+++ b/src/colors.js
@@ -129,14 +129,47 @@ export function getUnitColorProperty(parts) {
         "#aaaaaa"
     ];
 
-    const unitColorProperty = [
+    const standardColor = [
         "case",
         ["boolean", ["feature-state", "hover"], false],
         hoveredUnitColorStyle,
         unitColorStyle
     ];
 
+    const unitColorProperty = [
+        "case",
+        ["==", ["feature-state", "useBlendColor"], true],
+        ["feature-state", "blendColor"],
+        standardColor,
+    ];
+
     return unitColorProperty;
+}
+
+export function blendColors (colors) {
+    if (!colors || !Array.isArray(colors)) {
+        return colors;
+    } else if (colors.length === 1) {
+        return colors[0] * 1;
+    } else {
+        let r = 0, g = 0, b = 0;
+        colors.forEach((color) => {
+            if (typeof color === 'number') {
+                color = districtColors[color].hex;
+            }
+
+            r += parseInt("0x" + color.substring(1, 3));
+            g += parseInt("0x" + color.substring(3, 5));
+            b += parseInt("0x" + color.substring(5));
+        });
+        r = Math.round(r / colors.length).toString(16);
+        g = Math.round(g / colors.length).toString(16);
+        b = Math.round(b / colors.length).toString(16);
+        if (r.length === 1) { r = '0' + r; }
+        if (g.length === 1) { g = '0' + g; }
+        if (b.length === 1) { b = '0' + b; }
+        return '#' + [r, g, b].join('');
+    }
 }
 
 /**

--- a/src/colors.js
+++ b/src/colors.js
@@ -149,7 +149,11 @@ export function getUnitColorProperty(parts) {
 export function blendColors (colors) {
     if (!colors || !Array.isArray(colors)) {
         return colors;
-    } else if (colors.length === 1) {
+    }
+    colors = colors.filter(c => c !== null);
+    if (!colors.length) {
+        return null;
+    } else if (colors.length <= 1) {
         return colors[0] * 1;
     } else {
         let r = 0, g = 0, b = 0;

--- a/src/components/Charts/TooltipContent.js
+++ b/src/components/Charts/TooltipContent.js
@@ -6,7 +6,13 @@ function tooltipDots(features, parts) {
     let partCounts = zeros(parts.length);
     for (let feature of features) {
         if (feature.state.color !== null && feature.state.color !== undefined) {
-            partCounts[feature.state.color] += 1;
+            if (Array.isArray(feature.state.color)) {
+                feature.state.color.forEach(color => {
+                    partCounts[color] += 1;
+                });
+            } else {
+                partCounts[feature.state.color] += 1;
+            }
         }
     }
     if (sum(partCounts) === 0) {

--- a/src/components/PlaceMap.js
+++ b/src/components/PlaceMap.js
@@ -293,6 +293,21 @@ function modulesAvailable(feature, onClose, placeId) {
                 ${feature.properties.NAME}
             </h3>
             <div class="media__body">
+                ${(feature.properties.NAME == "North Carolina" && window.location.pathname.includes("community"))
+                    ? html`<ul class="places-list">
+                      <a href="https://deploy-preview-189--districtr-web.netlify.app/edit/4463">
+                        <li class="places-list__item ">
+                          <div class="place-name">
+                            North Carolina
+                          </div>
+                          <div class="place-info">Identify a community</div>
+                          <div class="place-info">
+                              Built out of blocks
+                          </div>
+                        </li>
+                      </a>
+                    </ul>`
+                    : ""}
                 ${feature.properties.NAME == "Illinois"
                     ? html`
                           <p>
@@ -304,7 +319,7 @@ function modulesAvailable(feature, onClose, placeId) {
                           </p>
                       `
                     : ""}
-                ${list.render()}
+                ${window.location.pathname.includes("community/nc") ? "" : list.render()}
             </div>
         </div>
     `;

--- a/src/components/Toolbar/BrushTool.js
+++ b/src/components/Toolbar/BrushTool.js
@@ -112,7 +112,7 @@ class BrushToolOptions {
                 ? CountyBrush(this.brush.county_brush, this.toggleCountyBrush)
                 : ""}
             ${this.colors.length > 1
-                ? BrushLock(this.brush.locked, this.toggleBrushLock)
+                ? BrushLock(this.brush.locked, this.toggleBrushLock, this.options)
                 : ""}
             ${UndoRedo(this.brush)}
         `;
@@ -134,7 +134,7 @@ const CountyBrush = (county_brush, toggle) => html`
     </div>
 `;
 
-const BrushLock = (locked, toggle) => html`
+const BrushLock = (locked, toggle, options) => html`
     <div class="ui-option">
         <label class="toolbar-checkbox">
             <input
@@ -144,7 +144,7 @@ const BrushLock = (locked, toggle) => html`
                 ?checked=${locked}
                 @change=${toggle}
             />
-            Lock already-drawn districts
+            Lock already-drawn ${options && options.community ? "communities" : "districts"}
         </label>
     </div>
 `;

--- a/src/map/Brush.js
+++ b/src/map/Brush.js
@@ -26,7 +26,8 @@ export default class Brush extends HoverWithRadius {
     clearUndo() {
         this.cursorUndo = 0;
         this.trackUndo = [{
-            color: this.color
+            color: "test",
+            initial: true,
         }];
     }
     setColor(color) {

--- a/src/map/CommunityBrush.js
+++ b/src/map/CommunityBrush.js
@@ -168,7 +168,16 @@ export default class CommunityBrush extends Brush {
             // eraser color "undefined" should act like a brush set to null
             let featureColor = atomicAction[fid].color,
                 finalColor = brushedColor; // only stays brushedColor for empty features
-            if (featureColor || (featureColor === 0 || featureColor === '0')) {
+            if (brushedColor === null || brushedColor === undefined) {
+                // redo erasing
+                if (Array.isArray(featureColor)) {
+                    featureColor.forEach((color) => {
+                        this.changedColors.add(color * 1);
+                    });
+                } else if (featureColor || (featureColor === 0 || featureColor === '0')) {
+                    this.changedColors.add(featureColor * 1);
+                }
+            } else if (featureColor || (featureColor === 0 || featureColor === '0')) {
                 // re-apply brushedColor to existing feature
                 if (Array.isArray(featureColor)) {
                     if (!featureColor.includes(brushedColor)) {

--- a/src/map/CommunityBrush.js
+++ b/src/map/CommunityBrush.js
@@ -8,7 +8,7 @@ export default class CommunityBrush extends Brush {
 
         this.brush_type = "community";
 
-        bindAll(["onMouseDown", "onMouseUp", "onClick", "onTouchStart"], this);
+        bindAll(["onMouseDown", "onMouseUp", "onClick", "onTouchStart", "_colorFeatures"], this);
     }
     _colorFeatures(filter) {
         let seenFeatures = new Set(),
@@ -19,55 +19,6 @@ export default class CommunityBrush extends Brush {
         }
         for (let feature of this.hoveredFeatures) {
             if (filter(feature)) {
-                if (this.county_brush) {
-                    let ps = feature.properties,
-                        countyFIPS = null,
-                        idSearch = (key, substr, fn) => {
-                            if (!ps[key]) {
-                                if (ps[key.toLowerCase()]) {
-                                    key = key.toLowerCase();
-                                } else {
-                                    return;
-                                }
-                            }
-                            if (substr) {
-                                return [key, ps[key].substring(0, substr)];
-                            } else {
-                                if (!fn) {
-                                    fn = x => x;
-                                }
-                                return [key, fn(ps[key])];
-                            }
-                        },
-                        nameSplice = (val) => {
-                            let name = val.split("-")[0].split(" ");
-                            name.splice(-1);
-                            return name.join(" ");
-                        };
-                    [countyProp, countyFIPS] = idSearch("GEOID10", 5)
-                        || idSearch("VTD", 5)
-                        // || idSearch("CNTYVTD", 3)
-                        // || idSearch("DsslvID", 2) // Utah
-                        // || idSearch("PRECODE", 2) // Oklahoma
-                        || idSearch("COUNTYFP10")
-                        || idSearch("COUNTY")
-                        || idSearch("CTYNAME")
-                        || idSearch("CNTYNAME")
-                        || idSearch("cnty_nm")
-                        || idSearch("locality")
-                        || idSearch("NAME", null, nameSplice)
-                        || idSearch("NAME10", null, nameSplice)
-                        || idSearch("Precinct", null, (val) => {
-                            // Oregon
-                            let name = val.split("_");
-                            name.splice(-1);
-                            return name.join("_");
-                        });
-                    if (countyFIPS) {
-                        seenCounties.add(countyFIPS);
-                    }
-                }
-
                 let fullColors = this.layer.getAssignment(feature.id);
                 if (this.color === null) {
                     fullColors = null;
@@ -86,7 +37,7 @@ export default class CommunityBrush extends Brush {
                 if (!seenFeatures.has(feature.id)) {
                     seenFeatures.add(feature.id);
                     for (let listener of this.listeners.colorfeature) {
-                        listener(feature, this.color);
+                        listener(feature, fullColors);
                     }
                 }
 

--- a/src/map/CommunityBrush.js
+++ b/src/map/CommunityBrush.js
@@ -1,6 +1,6 @@
 import Brush from "./Brush";
 import { bindAll } from "../utils";
-import { blendColors } from "../colors";
+import { blendColors, changeColorLuminance } from "../colors";
 
 export default class CommunityBrush extends Brush {
     constructor(layer, radius, color) {
@@ -18,8 +18,6 @@ export default class CommunityBrush extends Brush {
         }
         for (let feature of this.hoveredFeatures) {
             if (filter(feature)) {
-                feature.state.COI = true;
-
                 let fullColors = this.layer.getAssignment(feature.id);
                 if (this.color === null) {
                     fullColors = null;
@@ -60,9 +58,9 @@ export default class CommunityBrush extends Brush {
                 this.layer.setFeatureState(feature.id, {
                     ...feature.state,
                     color: fullColors,
-                    COI: true,
+                    useBlendColor: useBlendColor,
                     blendColor: blendColor,
-                    useBlendColor: useBlendColor
+                    blendHoverColor: changeColorLuminance(blendColor, -0.3)
                 });
                 // set color again here
                 // fixes a bug where we re-paint the same district repeatedly
@@ -70,12 +68,6 @@ export default class CommunityBrush extends Brush {
                 feature.state.color = fullColors;
                 feature.state.useBlendColor = useBlendColor;
                 feature.state.blendColor = blendColor;
-            } else {
-                feature.state.COI = true;
-                this.layer.setFeatureState(feature.id, {
-                    ...feature.state,
-                    COI: true
-                });
             }
         }
         for (let listener of this.listeners.colorend) {
@@ -121,7 +113,7 @@ export default class CommunityBrush extends Brush {
                 color: amendColor,
                 useBlendColor: useBlendColor,
                 blendColor: blendColor,
-                COI: true
+                blendHoverColor: changeColorLuminance(blendColor, -0.3)
             });
 
             // update subgroup totals (restoring old brush color)
@@ -194,20 +186,20 @@ export default class CommunityBrush extends Brush {
             // change map colors
             let featureState = this.layer.getFeatureState(fid);
             let useBlendColor = Array.isArray(finalColor) && (finalColor.length > 1),
-                blendColor = Array.isArray(finalColor) ? blendColors(finalColor) : finalColor;
+                blendColor = Array.isArray(finalColor) ? blendColors(finalColor)[0] : finalColor;
             this.layer.setFeatureState(fid, {
                 ...featureState,
                 color: finalColor,
                 useBlendColor: useBlendColor,
                 blendColor: blendColor,
-                COI: true
+                blendHoverColor: changeColorLuminance(blendColor, -0.3)
             });
 
             // update subgroup totals (restoring old brush color)
             for (let listener of listeners) {
                 listener({
                     id: fid,
-                    state: { color: featureColor, COI: true },
+                    state: { color: featureColor },
                     properties: atomicAction[fid].properties
                 }, finalColor);
             }

--- a/src/map/CommunityBrush.js
+++ b/src/map/CommunityBrush.js
@@ -12,8 +12,7 @@ export default class CommunityBrush extends Brush {
     }
     _colorFeatures(filter) {
         let seenFeatures = new Set(),
-            seenCounties = new Set(),
-            countyProp = "GEOID10";
+            seenCounties = new Set();
         if (this.color || this.color === 0 || this.color === '0') {
             this.changedColors.add(Number(this.color));
         }
@@ -76,20 +75,6 @@ export default class CommunityBrush extends Brush {
                     ...feature.state,
                     COI: true
                 });
-            }
-        }
-        if (this.county_brush && seenCounties.size > 0) {
-            seenCounties.forEach(fips => {
-                this.layer.setCountyState(fips, countyProp, {
-                    color: this.color
-                },
-                filter,
-                this.trackUndo[this.cursorUndo],
-                this.listeners.colorfeature,
-                true); // overlapping COI
-            });
-            for (let listener of this.listeners.colorop) {
-                listener();
             }
         }
         for (let listener of this.listeners.colorend) {

--- a/src/map/CommunityBrush.js
+++ b/src/map/CommunityBrush.js
@@ -1,66 +1,14 @@
-import { HoverWithRadius } from "./Hover";
+import Brush from "./Brush";
 import { bindAll } from "../utils";
+import { blendColors } from "../colors";
 
-export default class Brush extends HoverWithRadius {
+export default class CommunityBrush extends Brush {
     constructor(layer, radius, color) {
-        super(layer, radius);
+        super(layer, radius, color);
 
-        this.id = Math.random();
-        this.color = color;
-        this.coloring = false;
-        this.county_brush = false;
-        this.locked = false;
-        this.changedColors = new Set();
+        this.brush_type = "community";
 
-        this.listeners = {
-            colorend: [],
-            colorfeature: [],
-            colorop: [],
-            undo: [],
-            redo: []
-        };
-        bindAll(["onMouseDown", "onMouseUp", "onClick", "onTouchStart", "undo", "redo", "clearUndo"],
-            this);
-        this.clearUndo();
-    }
-    clearUndo() {
-        this.cursorUndo = 0;
-        this.trackUndo = [{
-            color: this.color
-        }];
-    }
-    setColor(color) {
-        this.color = parseInt(color);
-    }
-    startErasing() {
-        this._previousColor = this.color;
-        this.color = null;
-        this.erasing = true;
-    }
-    stopErasing() {
-        this.color = this._previousColor;
-        this.erasing = false;
-    }
-    hoverOn(features) {
-        this.hoveredFeatures = features;
-
-        if (this.coloring === true) {
-            this.colorFeatures();
-        } else {
-            super.hoverOn(features);
-        }
-    }
-    colorFeatures() {
-        if (this.locked && !this.erasing) {
-            this._colorFeatures(
-                feature =>
-                    feature.state.color === null ||
-                    feature.state.color === undefined ||
-                    isNaN(feature.state.color)
-            );
-        } else {
-            this._colorFeatures(feature => feature.state.color !== this.color);
-        }
+        bindAll(["onMouseDown", "onMouseUp", "onClick", "onTouchStart"], this);
     }
     _colorFeatures(filter) {
         let seenFeatures = new Set(),
@@ -120,6 +68,21 @@ export default class Brush extends HoverWithRadius {
                     }
                 }
 
+                let fullColors = this.layer.getAssignment(feature.id);
+                if (this.color === null) {
+                    fullColors = null;
+                } else if (fullColors === null || fullColors === undefined) {
+                    fullColors = this.color;
+                } else if (typeof fullColors === 'number' && fullColors !== this.color) {
+                    fullColors = [fullColors, this.color];
+                } else if (Array.isArray(fullColors) && !fullColors.includes(this.color)) {
+                    fullColors.push(this.color);
+                }
+
+                // Community of Interest flag for eraser behavior
+                let useBlendColor = Array.isArray(fullColors) && (fullColors.length > 1),
+                    blendColor = Array.isArray(fullColors) ? blendColors(fullColors) : fullColors;
+
                 if (!seenFeatures.has(feature.id)) {
                     seenFeatures.add(feature.id);
                     for (let listener of this.listeners.colorfeature) {
@@ -127,28 +90,40 @@ export default class Brush extends HoverWithRadius {
                     }
                 }
 
-                // remember feature's initial color once per paint event
-                // remember population data so it can be un-counted
+                feature.state.COI = true;
+
                 if (!this.trackUndo[this.cursorUndo][feature.id]) {
                     this.trackUndo[this.cursorUndo][feature.id] = {
                         properties: feature.properties,
-                        color: String(feature.state.color)
+                        color: feature.state.color
                     };
                 }
-                if (feature.state.color || feature.state.color === 0 || feature.state.color === '0') {
+                if (Array.isArray(feature.state.color)) {
+                    feature.state.color.forEach((color) => {
+                        this.changedColors.add(Number(color));
+                    });
+                } else if (feature.state.color || feature.state.color === 0 || feature.state.color === '0') {
                     this.changedColors.add(Number(feature.state.color));
                 }
 
                 this.layer.setFeatureState(feature.id, {
                     ...feature.state,
-                    color: this.color,
-                    hover: true
+                    color: fullColors,
+                    COI: true,
+                    blendColor: blendColor,
+                    useBlendColor: useBlendColor
                 });
-                feature.state.color = this.color;
+                // set color again here
+                // fixes a bug where we re-paint the same district repeatedly
+                // or fail to paint when fast-swiping
+                feature.state.color = fullColors;
+                feature.state.useBlendColor = useBlendColor;
+                feature.state.blendColor = blendColor;
             } else {
+                feature.state.COI = true;
                 this.layer.setFeatureState(feature.id, {
                     ...feature.state,
-                    hover: true
+                    COI: true
                 });
             }
         }
@@ -159,7 +134,8 @@ export default class Brush extends HoverWithRadius {
                 },
                 filter,
                 this.trackUndo[this.cursorUndo],
-                this.listeners.colorfeature);
+                this.listeners.colorfeature,
+                true); // overlapping COI
             });
             for (let listener of this.listeners.colorop) {
                 listener();
@@ -167,58 +143,6 @@ export default class Brush extends HoverWithRadius {
         }
         for (let listener of this.listeners.colorend) {
             listener();
-        }
-    }
-    onClick() {
-        this.changedColors = new Set();
-        this.colorFeatures();
-        if (!this.county_brush && Object.keys(this.trackUndo[this.cursorUndo]).length > 1) {
-            for (let listener of this.listeners.colorop) {
-                listener(false, this.changedColors);
-            }
-        }
-    }
-    onMouseDown(e) {
-        e.preventDefault();
-        e.originalEvent.preventDefault();
-        this.coloring = true;
-        this.changedColors = new Set();
-        window.addEventListener("mouseup", this.onMouseUp);
-        window.addEventListener("touchend", this.onMouseUp);
-        window.addEventListener("touchcancel", this.onMouseUp);
-
-        // after you undo, the cursor is in the middle of the undo stack (possible to redo an action)
-        // when you draw new material, it is no longer possible to redo
-        if (Object.keys(this.trackUndo[this.cursorUndo]).length > 1) {
-            if (this.cursorUndo < this.trackUndo.length - 1) {
-                this.trackUndo = this.trackUndo.slice(0, this.cursorUndo + 1);
-            }
-
-            // limit number of changes in the stack
-            if (this.trackUndo.length > 9) {
-                this.trackUndo = this.trackUndo.slice(1);
-            }
-
-            this.trackUndo.push({
-                color: this.color
-            });
-            this.cursorUndo = this.trackUndo.length - 1;
-        }
-    }
-    onMouseUp() {
-        this.coloring = false;
-        window.removeEventListener("mouseup", this.onMouseUp);
-        window.removeEventListener("touchend", this.onMouseUp);
-        window.removeEventListener("touchcancel", this.onMouseUp);
-        if (Object.keys(this.trackUndo[this.cursorUndo]).length > 1) {
-            for (let listener of this.listeners.colorop) {
-                listener(false, this.changedColors);
-            }
-        }
-    }
-    onTouchStart(e) {
-        if (e.points && e.points.length <= 1) {
-            this.onMouseDown(e);
         }
     }
     undo() {
@@ -235,20 +159,32 @@ export default class Brush extends HoverWithRadius {
             // eraser color "undefined" should act like a brush set to null
             let amendColor = atomicAction[fid].color;
             if ((amendColor === 0 || amendColor === '0') || amendColor) {
-                amendColor = Number(atomicAction[fid].color);
-                if (isNaN(amendColor)) {
-                    amendColor = null;
+                if (Array.isArray(amendColor)) {
+                    amendColor.forEach((color) => {
+                        this.changedColors.add(amendColor);
+                    });
+                } else {
+                    amendColor = Number(atomicAction[fid].color);
+                    if (isNaN(amendColor)) {
+                        amendColor = null;
+                    } else {
+                        this.changedColors.add(amendColor);
+                    }
                 }
             } else {
                 amendColor = null;
             }
-            this.changedColors.add(amendColor);
 
             // change map colors
             let featureState = this.layer.getFeatureState(fid);
+            let useBlendColor = Array.isArray(amendColor) && (amendColor.length > 1),
+                blendColor = Array.isArray(amendColor) ? blendColors(amendColor) : amendColor;
             this.layer.setFeatureState(fid, {
                 ...featureState,
-                color: amendColor
+                color: amendColor,
+                useBlendColor: useBlendColor,
+                blendColor: blendColor,
+                COI: true
             });
 
             // update subgroup totals (restoring old brush color)
@@ -294,23 +230,45 @@ export default class Brush extends HoverWithRadius {
 
             // eraser color "undefined" should act like a brush set to null
             let amendColor = atomicAction[fid].color;
+            let finalColor = brushedColor;
             if ((amendColor === 0 || amendColor === '0') || amendColor) {
-                amendColor = Number(atomicAction[fid].color);
+                if (Array.isArray(amendColor)) {
+                    amendColor.forEach((color) => {
+                        this.changedColors.add(amendColor);
+                    });
+                    if (!amendColor.includes(brushedColor)) {
+                        amendColor.push(finalColor);
+                    }
+                } else {
+                    amendColor = Number(atomicAction[fid].color);
+                    if (isNaN(amendColor)) {
+                        amendColor = null;
+                    } else if (amendColor !== brushedColor && brushedColor !== null) {
+                        finalColor = [amendColor, brushedColor];
+                        this.changedColors.add(amendColor);
+                    }
+                }
             } else {
                 amendColor = null;
             }
-            this.changedColors.add(amendColor);
 
             // change map colors
+            let featureState = this.layer.getFeatureState(fid);
+            let useBlendColor = Array.isArray(finalColor) && (finalColor.length > 1),
+                blendColor = Array.isArray(finalColor) ? blendColors(finalColor) : finalColor;
             this.layer.setFeatureState(fid, {
-                color: brushedColor
+                ...featureState,
+                color: finalColor,
+                useBlendColor: useBlendColor,
+                blendColor: blendColor,
+                COI: true
             });
 
             // update subgroup totals (restoring old brush color)
             for (let listener of listeners) {
                 listener({
                     id: fid,
-                    state: { color: amendColor },
+                    state: { color: amendColor, COI: true },
                     properties: atomicAction[fid].properties
                 }, brushedColor);
             }
@@ -324,40 +282,5 @@ export default class Brush extends HoverWithRadius {
         for (let listener of this.listeners.redo) {
             listener(this.cursorUndo >= this.trackUndo.length - 1);
         }
-    }
-    activate(mouseover) {
-        super.activate(mouseover);
-        if (mouseover) {
-            return;
-        }
-
-        this.layer.map.getCanvas().classList.add("brush-tool");
-        this.layer.map.dragPan.disable();
-        this.layer.map.touchZoomRotate.disable();
-        this.layer.map.doubleClickZoom.disable();
-
-        this.layer.on("click", this.onClick);
-        this.layer.map.on("touchstart", this.onTouchStart);
-        this.layer.map.on("mousedown", this.onMouseDown);
-    }
-
-    deactivate(mouseover) {
-        super.deactivate(mouseover);
-        if (mouseover) {
-            return;
-        }
-
-        this.hoverOff();
-        this.layer.map.getCanvas().classList.remove("brush-tool");
-        this.layer.map.dragPan.enable();
-        this.layer.map.doubleClickZoom.enable();
-        this.layer.map.touchZoomRotate.enable();
-
-        this.layer.off("click", this.onClick);
-        this.layer.map.off("touchstart", this.onMouseDown);
-        this.layer.map.off("mousedown", this.onMouseDown);
-    }
-    on(event, listener) {
-        this.listeners[event].push(listener);
     }
 }

--- a/src/map/Layer.js
+++ b/src/map/Layer.js
@@ -92,7 +92,7 @@ export default class Layer {
             state
         );
     }
-    setCountyState(fips, countyProp, setState, filter, undoInfo, tallyListeners, arrayLike) {
+    setCountyState(fips, countyProp, setState, filter, undoInfo, tallyListeners) {
         let seenFeatures = new Set(),
             filterStrings = [
                 "all",
@@ -120,35 +120,11 @@ export default class Layer {
                         listener(feature, setState.color);
                     });
 
-                    let setColor = setState.color,
-                        currentColor = feature.state.color;
-                    if (arrayLike) {
-                        if (typeof currentColor === 'number') {
-                            currentColor = [currentColor];
-                        } else if (currentColor && currentColor.includes(setState.color)) {
-                            return;
-                        }
-
-                        if (setState.color === null) {
-                            // erasing all colors
-                            setColor = null;
-                        } else if (currentColor || currentColor === '0' || currentColor === 0) {
-                            // adding to colors
-                            setColor = [setState.color].concat(currentColor);
-                        }
-                    }
-
-                    feature.state.COI = true;
-                    let useBlendColor = Array.isArray(setColor) && (setColor.length > 1),
-                        blendColor = Array.isArray(setColor) ? blendColors(setColor) : setColor;
                     this.setFeatureState(feature.id, {
                         ...feature.state,
-                        color: setColor,
-                        blendColor: blendColor,
-                        useBlendColor: useBlendColor,
-                        COI: true
+                        color: setState.color
                     });
-                    feature.state.color = setColor;
+                    feature.state.color = setState.color;
                 }
             }
         });

--- a/src/map/NumberMarkers.js
+++ b/src/map/NumberMarkers.js
@@ -90,17 +90,23 @@ export default function NumberMarkers(state, brush) {
                 if (plan.assignment[unit_id] === null) {
                     return;
                 }
-                let district_num = Number(plan.assignment[unit_id]);
-                seenDistricts.add(district_num);
-                if (
-                    (district_num || (district_num === 0))
-                    && (!colorsAffected || colorsAffected.has(district_num))
-                ) {
-                    if (markers[district_num]) {
-                        markers[district_num].push(unit_id);
-                    } else {
-                        markers[district_num] = [unit_id];
+                let markDistrict = (district_num) => {
+                    seenDistricts.add(district_num);
+                    if (
+                        (district_num || (district_num === 0))
+                        && (!colorsAffected || colorsAffected.has(district_num))
+                    ) {
+                        if (markers[district_num]) {
+                            markers[district_num].push(unit_id);
+                        } else {
+                            markers[district_num] = [unit_id];
+                        }
                     }
+                }
+                if (Array.isArray(plan.assignment[unit_id])) {
+                    plan.assignment[unit_id].forEach(markDistrict);
+                } else {
+                    markDistrict(Number(plan.assignment[unit_id]));
                 }
             });
 

--- a/src/models/State.js
+++ b/src/models/State.js
@@ -68,6 +68,8 @@ class DistrictingPlan {
                     }
                 }
             }
+        } else if (part === null) {
+            delete this.assignment[featureId];
         } else {
             this.assignment[featureId] = part;
         }

--- a/src/models/State.js
+++ b/src/models/State.js
@@ -48,12 +48,15 @@ class DistrictingPlan {
     }
     update(feature, part) {
         let featureId = this.idColumn.getValue(feature);
-        if (this.problem.type === "community" && part !== null) {
+        if (this.problem.type === "community" && (part || (part === 0))) {
+            // overlapping communities possible
             let current = this.assignment[featureId];
-            if (current === null || current === undefined) {
+            if (!current && (current !== 0)) {
+                // no current state; set to brush
                 this.assignment[featureId] = part;
             } else {
                 if (!Array.isArray(current)) {
+                    // current state is not an array yet
                     this.assignment[featureId] = [current];
                 }
                 if (Array.isArray(part)) {
@@ -62,15 +65,15 @@ class DistrictingPlan {
                             this.assignment[featureId].push(p);
                         }
                     });
-                } else {
-                    if (!this.assignment[featureId].includes(part)) {
-                        this.assignment[featureId].push(part);
-                    }
+                } else if (!this.assignment[featureId].includes(part)) {
+                    this.assignment[featureId].push(part);
                 }
             }
-        } else if (part === null) {
+        } else if (!part) {
+            // erasing this part
             delete this.assignment[featureId];
         } else {
+            // districting (only one assignment possible at a time)
             this.assignment[featureId] = part;
         }
     }

--- a/src/models/State.js
+++ b/src/models/State.js
@@ -48,28 +48,7 @@ class DistrictingPlan {
     }
     update(feature, part) {
         let featureId = this.idColumn.getValue(feature);
-        if (this.problem.type === "community" && (part || (part === 0))) {
-            // overlapping communities possible
-            let current = this.assignment[featureId];
-            if (!current && (current !== 0)) {
-                // no current state; set to brush
-                this.assignment[featureId] = part;
-            } else {
-                if (!Array.isArray(current)) {
-                    // current state is not an array yet
-                    this.assignment[featureId] = [current];
-                }
-                if (Array.isArray(part)) {
-                    part.forEach((p) => {
-                        if (!this.assignment[featureId].includes(p)) {
-                            this.assignment[featureId].push(p);
-                        }
-                    });
-                } else if (!this.assignment[featureId].includes(part)) {
-                    this.assignment[featureId].push(part);
-                }
-            }
-        } else if (!part) {
+        if (!part && (part !== 0)) {
             // erasing this part
             delete this.assignment[featureId];
         } else {

--- a/src/models/State.js
+++ b/src/models/State.js
@@ -47,7 +47,30 @@ class DistrictingPlan {
         this.idColumn = idColumn;
     }
     update(feature, part) {
-        this.assignment[this.idColumn.getValue(feature)] = part;
+        let featureId = this.idColumn.getValue(feature);
+        if (this.problem.type === "community" && part !== null) {
+            let current = this.assignment[featureId];
+            if (current === null || current === undefined) {
+                this.assignment[featureId] = part;
+            } else {
+                if (!Array.isArray(current)) {
+                    this.assignment[featureId] = [current];
+                }
+                if (Array.isArray(part)) {
+                    part.forEach((p) => {
+                        if (!this.assignment[featureId].includes(p)) {
+                            this.assignment[featureId].push(p);
+                        }
+                    });
+                } else {
+                    if (!this.assignment[featureId].includes(part)) {
+                        this.assignment[featureId].push(part);
+                    }
+                }
+            }
+        } else {
+            this.assignment[featureId] = part;
+        }
     }
     serialize() {
         return {

--- a/src/models/Subgroup.js
+++ b/src/models/Subgroup.js
@@ -36,15 +36,41 @@ export class Subgroup extends NumericalColumn {
         );
     }
     update(feature, color) {
+        let oldColors = String(feature.state ?
+            (feature.state.color === undefined ? "" : feature.state.color)
+            : "").split(",");
+        let newColors = String(color).split(",");
+
         if (color !== undefined && color !== null) {
-            this.data[color] += this.getValue(feature);
+            if (!oldColors.includes(String(color))) {
+                // newColors usually receives one color at a time
+                // except when loading multiple colors from a community plan
+                newColors.forEach((c) => {
+                    this.data[Number(c)] += this.getValue(feature);
+                });
+            }
         }
         if (
             feature.state !== undefined &&
             feature.state.color !== undefined &&
             feature.state.color !== null
         ) {
-            this.data[feature.state.color] -= this.getValue(feature);
+            if (color === null || !feature.state.COI) {
+                // this happens on districting whenever a color is replaced
+                // this happens on community only when erasing (overlap allowed)
+                oldColors.forEach((oldColor) => {
+                    this.data[Number(oldColor)] -= this.getValue(feature);
+                });
+            }
+            // else if (feature.state.COI && oldColors.length > 1 && newColors.length) {
+            //     console.log(oldColors);
+            //     console.log('to');
+            //     console.log(newColors);
+            //     oldColors.filter(c => !newColors.includes(String(c))).forEach((oldColor) => {
+            //         console.log('remove ' + oldColor);
+            //         this.data[Number(oldColor)] -= this.getValue(feature);
+            //     });
+            // }
         }
     }
     getAbbreviation() {

--- a/src/models/Subgroup.js
+++ b/src/models/Subgroup.js
@@ -54,22 +54,15 @@ export class Subgroup extends NumericalColumn {
                     });
             }
         }
-        if (
-            feature.state !== undefined &&
-            feature.state.color !== undefined &&
-            feature.state.color !== null
-        ) {
-            if (color === null || !feature.state.COI) {
-                // this happens on districting whenever a color is replaced
-                // this happens on community only when erasing (overlap allowed)
-                oldColors.filter(c => (c || (c === 0))).forEach((oldColor) => {
-                    if (!newColors.includes(oldColor)) {
-                        // console.log("subtract from " + Number(oldColor));
-                        this.data[Number(oldColor)] -= this.getValue(feature);
-                    }
-                });
+
+        // this happens on districting whenever a color is replaced
+        // this happens on community only when erasing (overlap allowed)
+        oldColors.filter(c => (c || (c === 0))).forEach((oldColor) => {
+            if (!newColors.includes(oldColor)) {
+                // console.log("subtract from " + Number(oldColor));
+                this.data[Number(oldColor)] -= this.getValue(feature);
             }
-        }
+        });
     }
     getAbbreviation() {
         if (ABBREVIATIONS.hasOwnProperty(this.key)) {

--- a/src/models/lib/assign.js
+++ b/src/models/lib/assign.js
@@ -44,7 +44,9 @@ function assign(state, feature, partId) {
     }
     state.update(feature, partId);
     partId.forEach((p) => {
-        state.parts[p].visible = true;
+        if (p || (p === 0)) {
+            state.parts[p].visible = true;
+        }
     });
     state.units.setAssignment(feature, partId);
 }

--- a/src/models/lib/assign.js
+++ b/src/models/lib/assign.js
@@ -39,10 +39,13 @@ export function getAssignedUnitIds(assignment) {
 }
 
 function assign(state, feature, partId) {
-    state.update(feature, partId);
-    for (let i = 0; i <= partId; i++) {
-        state.parts[i].visible = true;
+    if (typeof partId === 'number') {
+        partId = [partId];
     }
+    state.update(feature, partId);
+    partId.forEach((p) => {
+        state.parts[p].visible = true;
+    });
     state.units.setAssignment(feature, partId);
 }
 

--- a/src/plugins/data-layers-plugin.js
+++ b/src/plugins/data-layers-plugin.js
@@ -274,6 +274,8 @@ export default function DataLayersPlugin(editor) {
         state.plan.problem.type === "community"
             ? "Show communities"
             : "Show districts";
+    const districtNumberLabel = "Show " + (state.plan.problem.type === "community" ? "community" : "district")
+        + " numbers";
     tab.addSection(
         () => html`
             <h4>${districtsHeading}</h4>
@@ -284,7 +286,7 @@ export default function DataLayersPlugin(editor) {
             ${(["chicago_community_areas"].includes(state.units.sourceId)
               || !spatial_abilities(state.place.id).number_markers
             ) ? null
-                : toggle("Show district numbers", false, checked => {
+                : toggle(districtNumberLabel, false, checked => {
                     let opacity = checked ? 1 : 0;
                     state.numbers.forEach((number) => {
                         number.setOpacity(Math.round(opacity))

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -23,12 +23,12 @@ export default function ToolsPlugin(editor) {
     brush.on("colorend", state.render);
     brush.on("colorend", toolbar.unsave);
 
-    let brushOptions = {};
-    if (state.problem.type === "community") {
-        brushOptions.community = true;
-    } else if (spatial_abilities(state.place.id).county_brush) {
-        brushOptions.county_brush = new HoverWithRadius(state.counties, 20);
-    }
+    let brushOptions = {
+        community: (state.problem.type === "community"),
+        county_brush: ((spatial_abilities(state.place.id).county_brush && (state.problem.type !== "community"))
+            ? new HoverWithRadius(state.counties, 20)
+            : null)
+    };
 
     let planNumbers = NumberMarkers(state, brush);
     const c_checker = ContiguityChecker(state, brush);

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -6,6 +6,7 @@ import InspectTool from "../components/Toolbar/InspectTool";
 import PanTool from "../components/Toolbar/PanTool";
 import LandmarkTool from "../components/Toolbar/LandmarkTool";
 import Brush from "../map/Brush";
+import CommunityBrush from "../map/CommunityBrush";
 import { HoverWithRadius } from "../map/Hover";
 import NumberMarkers from "../map/NumberMarkers";
 import ContiguityChecker from "../map/contiguity";
@@ -15,7 +16,9 @@ import { download, spatial_abilities /* , stateNameToFips */ } from "../utils";
 
 export default function ToolsPlugin(editor) {
     const { state, toolbar } = editor;
-    const brush = new Brush(state.units, 20, 0);
+    const brush = (state.problem.type === 'community')
+        ? new CommunityBrush(state.units, 20, 0)
+        : new Brush(state.units, 20, 0);
     brush.on("colorfeature", state.update);
     brush.on("colorend", state.render);
     brush.on("colorend", toolbar.unsave);

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -23,8 +23,10 @@ export default function ToolsPlugin(editor) {
     brush.on("colorend", state.render);
     brush.on("colorend", toolbar.unsave);
 
-    let brushOptions = { community: state.problem.type === "community" };
-    if (spatial_abilities(state.place.id).county_brush) {
+    let brushOptions = {};
+    if (state.problem.type === "community") {
+        brushOptions.community = true;
+    } else if (spatial_abilities(state.place.id).county_brush) {
         brushOptions.county_brush = new HoverWithRadius(state.counties, 20);
     }
 

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -20,7 +20,7 @@ export default function ToolsPlugin(editor) {
     brush.on("colorend", state.render);
     brush.on("colorend", toolbar.unsave);
 
-    let brushOptions = {};
+    let brushOptions = { community: state.problem.type === "community" };
     if (spatial_abilities(state.place.id).county_brush) {
         brushOptions.county_brush = new HoverWithRadius(state.counties, 20);
     }


### PR DESCRIPTION
## Features
- In 'community of interest' maps, instead of replacing one group with another, they can overlap
- Overlap appears as an RGB blend of colors
- Eraser removes population from all areas

![Screen Shot 2019-09-23 at 11 59 34 AM](https://user-images.githubusercontent.com/643918/65442130-a49f2880-ddf9-11e9-9211-9c4de5964416.png)

## Compatibility
Old plans (including old Community of Interest plans) should be compatible
Redistricting map tool should be unaffected
localStorage (refreshing map) should restore map and population counts
Update: Inspect tool works properly on overlap areas

## Future

Color-blending can be weird (especially with > 2 colors)

We previously discussed a line border or pattern to better show these overlaps - I think this is a better way to do it, but it's also going to be more technical, so it would be good to make overlaps possible first, and then work out the cartography / JS options to make it visually appealing