### PR TITLE
Drop saved JSON or CSV files onto map

### DIFF
--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -57,11 +57,12 @@ function exportPlanAsJSON(state) {
     download(`districtr-plan-${serialized.id}.json`, text);
 }
 
-function exportPlanAsAssignmentFile(plan, delimiter = ",", extension = "csv") {
-    const text = Object.keys(plan.assignment)
-        .map(unitId => `${unitId}${delimiter}${plan.assignment[unitId]}`)
+function exportPlanAsAssignmentFile(state, delimiter = ",", extension = "csv") {
+    let text = `"id-${state.place.id}-${state.units.id}"${delimiter}assignment\n`;
+    text += Object.keys(state.plan.assignment)
+        .map(unitId => `${unitId}${delimiter}${state.plan.assignment[unitId]}`)
         .join("\n");
-    download(`assignment-${plan.id}.${extension}`, text);
+    download(`assignment-${state.plan.id}.${extension}`, text);
 }
 
 function getMenuItems(state) {
@@ -88,7 +89,7 @@ function getMenuItems(state) {
         },
         {
             name: "Export as assignment CSV",
-            onClick: () => exportPlanAsAssignmentFile(state.plan)
+            onClick: () => exportPlanAsAssignmentFile(state)
         }
     ];
     return items;

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -58,7 +58,9 @@ function exportPlanAsJSON(state) {
 }
 
 function exportPlanAsAssignmentFile(state, delimiter = ",", extension = "csv") {
-    let text = `"id-${state.place.id}-${state.units.id}"${delimiter}assignment\n`;
+    let text = `"id-${state.place.id}-${state.units.id}-${state.problem.numberOfParts}`;
+    text += `-${state.problem.pluralNoun.replace(/\s+/g, "")}"`;
+    text += `${delimiter}assignment\n`;
     text += Object.keys(state.plan.assignment)
         .map(unitId => `${unitId}${delimiter}${state.plan.assignment[unitId]}`)
         .join("\n");

--- a/src/routes.js
+++ b/src/routes.js
@@ -75,15 +75,18 @@ export function loadPlanFromJSON(planRecord) {
 
 export function loadPlanFromCSV(assignmentList, state) {
     let rows = assignmentList.split("\n");
-    let headers = rows[0].split(",");
+    let headers = rows[0].replace(/"/g, "").trim().split(",");
     if (
-        headers[0].indexOf("\"id-") === 0
+        headers[0].indexOf("id-") === 0
         && headers[0].split("-").length === 3
     ) {
         // new format, verify units match
         //id-state.place.id-state.units.id
         let placeId = headers[0].split("-")[1],
             unitId = headers[0].split("-")[2];
+        if (unitId.includes("_")) {
+            unitId = unitId.split("_")[1];
+        }
 
         if (placeId !== state.place.id) {
             throw new Error("CSV is for a different module (another state or region).");

--- a/src/routes.js
+++ b/src/routes.js
@@ -73,6 +73,50 @@ export function loadPlanFromJSON(planRecord) {
     });
 }
 
+export function loadPlanFromCSV(assignmentList, state) {
+    let rows = assignmentList.split("\n");
+    let headers = rows[0].split(",");
+    if (
+        headers[0].indexOf("\"id-") === 0
+        && headers[0].split("-").length === 3
+    ) {
+        // new format, verify units match
+        //id-state.place.id-state.units.id
+        let placeId = headers[0].split("-")[1],
+            unitId = headers[0].split("-")[2];
+
+        if (placeId !== state.place.id) {
+            throw new Error("CSV is for a different module (another state or region).");
+        } else if (unitId !== state.units.id) {
+            throw new Error("CSV is for this module but a different divison (e.g. blocks, precincts).");
+        }
+    } else {
+        // old format, no column headers
+        headers = null;
+    }
+    let planRecord = state;
+    planRecord.assignment = {};
+    return listPlaces().then(places => {
+        rows.forEach((row, index) => {
+            if (index > 0 || !headers) {
+                let cols = row.split(","),
+                    key = cols[0] * 1,
+                    val = cols[1] * 1;
+
+                if (key && !isNaN(val)) {
+                    planRecord.assignment[key] = val;
+                }
+            }
+        });
+
+        const place = places.find(p => p.id === planRecord.place.id);
+        return {
+            ...planRecord,
+            place
+        };
+    });
+}
+
 export function loadPlanFromURL(url) {
     return fetch(url)
         .then(r => r.json())

--- a/src/routes.js
+++ b/src/routes.js
@@ -109,8 +109,10 @@ export function loadPlanFromCSV(assignmentList, state) {
         rows.forEach((row, index) => {
             if (index > 0 || !headers) {
                 let cols = row.split(","),
-                    key = cols[0] * 1,
-                    val = cols[1] * 1;
+                    val = cols[1] * 1,
+                    key = (isNaN(cols[0] * 1) || cols[0][0] === "0")
+                        ? cols[0]
+                        : cols[0] * 1;
 
                 if (key && !isNaN(val)) {
                     planRecord.assignment[key] = val;

--- a/src/views/edit.js
+++ b/src/views/edit.js
@@ -96,6 +96,20 @@ export default function renderEditView() {
             window.history.replaceState({}, "Districtr", shortPlanName);
         }
 
+        function dropHandler(ev) {
+            ev.preventDefault();
+            if (ev.dataTransfer.items) {
+                ev.dataTransfer.items.forEach((f) => {
+                    console.log(f);
+                });
+            } else {
+                (ev.dataTransfer.files || []).forEach((f) => {
+                    console.log(f);
+                });
+            }
+        }
+        document.body.ondrop = dropHandler;
+
         mapState.map.on("load", () => {
             let state = new State(mapState.map, context, () => {
                 window.document.title = "Districtr";

--- a/src/views/edit.js
+++ b/src/views/edit.js
@@ -1,7 +1,13 @@
 import { html, render } from "lit-html";
 import { MapState } from "../map";
 import State from "../models/State";
-import { loadPlanFromURL, getContextFromStorage, navigateTo } from "../routes";
+import {
+    loadPlanFromURL,
+    loadPlanFromJSON,
+    loadPlanFromCSV,
+    getContextFromStorage,
+    navigateTo
+} from "../routes";
 import Editor from "../models/Editor";
 import ToolsPlugin from "../plugins/tools-plugin";
 import EvaluationPlugin from "../plugins/evaluation-plugin";
@@ -56,66 +62,93 @@ function getPlanContext() {
     }
 }
 
-export default function renderEditView() {
-    getPlanContext().then(context => {
-        const root = document.getElementById("root");
-        root.className = "";
-        render(
-            html`
-                <div id="map"></div>
-                <div id="toolbar"></div>
-            `,
-            root
-        );
-        const mapState = new MapState(
-            "map",
-            {
-                bounds: context.units.bounds,
-                fitBoundsOptions: {
-                    padding: {
-                        top: 50,
-                        right: 50,
-                        left: 50,
-                        bottom: 50
+function loadContext(context) {
+    const root = document.getElementById("root");
+    root.className = "";
+    render(
+        html`
+            <div id="map"></div>
+            <div id="toolbar"></div>
+        `,
+        root
+    );
+    const mapState = new MapState(
+        "map",
+        {
+            bounds: context.units.bounds,
+            fitBoundsOptions: {
+                padding: {
+                    top: 50,
+                    right: 50,
+                    left: 50,
+                    bottom: 50
+                }
+            }
+        },
+        getMapStyle(context)
+    );
+    window.document.title = "Loading... | Districtr";
+
+    // display shorter URL
+    if (window.history && window.history.replaceState
+        && getPlanURLFromQueryParam()
+        && window.location.hostname !== 'localhost'
+        && window.location.hash && window.location.hash === "#plan") {
+
+        let shortPlanName = getPlanURLFromQueryParam().split("/");
+        shortPlanName = shortPlanName[2].replace("-plans", "") + "/"
+            + shortPlanName[3].split(".")[0];
+        window.history.replaceState({}, "Districtr", shortPlanName);
+    }
+
+    // block of event handlers; drop a plan JSON file onto the map
+    function planHandler(f) {
+        let plan = f.getAsFile();
+        if (plan.name.includes(".json") || plan.name.includes(".csv")) {
+            let reader = new FileReader();
+            reader.onload = (e) => {
+                if (plan.name.includes(".json")) {
+                    let planData = JSON.parse(reader.result);
+                    if (planData.place.id !== context.place.id) {
+                        let conf = window.confirm("Switch locations to load this plan file?");
+                        if (!conf) {
+                            return;
+                        }
+                    }
+                    loadPlanFromJSON(planData).then(loadContext);
+                } else {
+                    // CSV
+                    try {
+                        loadPlanFromCSV(reader.result, context).then(loadContext);
+                    } catch (e) {
+                        window.alert(e.message);
                     }
                 }
-            },
-            getMapStyle(context)
-        );
-        window.document.title = "Loading... | Districtr";
-
-        // display shorter URL
-        if (window.history && window.history.replaceState
-            && getPlanURLFromQueryParam()
-            && window.location.hostname !== 'localhost'
-            && window.location.hash && window.location.hash === "#plan") {
-
-            let shortPlanName = getPlanURLFromQueryParam().split("/");
-            shortPlanName = shortPlanName[2].replace("-plans", "") + "/"
-                + shortPlanName[3].split(".")[0];
-            window.history.replaceState({}, "Districtr", shortPlanName);
+            };
+            reader.readAsText(plan);
         }
-
-        function dropHandler(ev) {
-            ev.preventDefault();
-            if (ev.dataTransfer.items) {
-                ev.dataTransfer.items.forEach((f) => {
-                    console.log(f);
-                });
-            } else {
-                (ev.dataTransfer.files || []).forEach((f) => {
-                    console.log(f);
-                });
-            }
+    }
+    document.body.ondrop = (ev) => {
+        ev.preventDefault();
+        if (ev.dataTransfer.items && ev.dataTransfer.items.length) {
+            planHandler(ev.dataTransfer.items[0]);
+        } else if (ev.dataTransfer.files && ev.dataTransfer.files.length) {
+            planHandler(ev.dataTransfer.files[0]);
         }
-        document.body.ondrop = dropHandler;
+    };
+    document.body.ondragover = (ev) => {
+        ev.preventDefault();
+    };
 
-        mapState.map.on("load", () => {
-            let state = new State(mapState.map, context, () => {
-                window.document.title = "Districtr";
-            });
-            let editor = new Editor(state, mapState, getPlugins(context));
-            editor.render();
+    mapState.map.on("load", () => {
+        let state = new State(mapState.map, context, () => {
+            window.document.title = "Districtr";
         });
+        let editor = new Editor(state, mapState, getPlugins(context));
+        editor.render();
     });
+}
+
+export default function renderEditView() {
+    getPlanContext().then(loadContext);
 }


### PR DESCRIPTION
Mostly straightforward. Completely reloads the map with this JSON or CSV, as if you were using the JSON file tool in /new

Warns you if you are loading JSON or CSV of a different state (when possible)

```renderEditView``` would fetch the plan and then execute an internal, anonymous function to load the map. We want to call that function to load new plans, so I separated it out and call it ```loadContext```

Adds a header row to CSVs, so we can remember which place / unit-type it belongs to.