### PR TITLE
Improve map loading (modal and community of interest)

### DIFF
--- a/src/models/lib/assign.js
+++ b/src/models/lib/assign.js
@@ -40,7 +40,9 @@ export function getAssignedUnitIds(assignment) {
 
 function assign(state, feature, partId) {
     state.update(feature, partId);
-    state.parts[partId].visible = true;
+    for (let i = 0; i <= partId; i++) {
+        state.parts[i].visible = true;
+    }
     state.units.setAssignment(feature, partId);
 }
 

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -40,10 +40,16 @@ export default function ToolsPlugin(editor) {
     toolbar.setMenuItems(getMenuItems(editor.state));
 
     // show about modal on startup by default
-    // exceptions if you are on localhost or set 'dev' in URL
+    // exceptions if you last were on this map, or set 'dev' in URL
     try {
-        if (window.location.href.indexOf('dev') === -1) {
+        if (
+            (window.location.href.indexOf("dev") === -1)
+            && (
+                !localStorage || (localStorage.getItem("lastVisit") !== state.place.id)
+            )
+        ) {
             renderAboutModal(editor.state);
+            localStorage.setItem("lastVisit", state.place.id);
         }
     } catch(e) {
         // likely no About page exists - silently fail to console


### PR DESCRIPTION
- Modal shows up on your first visit to the map, won't show up again until you switch maps
- Fixes a very specific bug on Communities of Interest, where if you skip a color (for example, coloring in only Community 1 and 3), when you reload the map, unused colors (Community 2) will be missing. This was affecting the communities dropdown and adding new communities.