### PR TITLE
Make Share/Save feature more prominent

### DIFF
--- a/sass/app.scss
+++ b/sass/app.scss
@@ -139,6 +139,61 @@ select {
     }
 }
 
+#save-popup {
+    display: none;
+    visibility: hidden;
+    top: 42px;
+    left: 10px;
+    right: 10px;
+    -webkit-transform-origin: right top;
+    transform-origin: right top;
+    margin: .7em 0 0;
+    position: absolute;
+    z-index: 1900;
+    border: 1px solid #ddd;
+    background: #fff;
+    padding: 1em;
+    border-radius: .3rem;
+    -webkit-box-shadow: 0 2px 4px 0 rgba(34,36,38,.12), 0 2px 10px 0 rgba(34,36,38,.15);
+    box-shadow: 0 2px 4px 0 rgba(34,36,38,.12), 0 2px 10px 0 rgba(34,36,38,.15);
+
+    &.show {
+        display: block;
+        visibility: visible;
+
+        strong {
+            display: block;
+        }
+
+        button {
+            cursor: pointer;
+
+            &.close-button {
+                float: right;
+                border: 2px solid #000;
+                font-weight: bold;
+            }
+        }
+    }
+
+    &:before {
+        top: -.3em;
+        left: 70%;
+        -webkit-box-shadow: -1px -1px 0 0 #bababc;
+        box-shadow: -1px -1px 0 0 #bababc;
+        background: #fff;
+        position: absolute;
+        content: '';
+        width: .7em;
+        height: .7em;
+        -webkit-transform: rotate(45deg);
+        transform: rotate(45deg);
+        z-index: 2;
+        -webkit-box-sizing: inherit;
+        box-sizing: inherit;
+    }
+}
+
 @media only screen and (max-width: 900px) {
     #mobile-upload {
         display: block;

--- a/sass/app.scss
+++ b/sass/app.scss
@@ -165,6 +165,11 @@ select {
             display: block;
         }
 
+        code {
+            display: block;
+            word-break: break-all;
+        }
+
         button {
             cursor: pointer;
 

--- a/sass/app.scss
+++ b/sass/app.scss
@@ -115,3 +115,36 @@ select {
 .dropdown {
     transition-duration: 60ms;
 }
+
+#mobile-upload {
+    display: none;
+}
+
+#desktop-upload {
+    display: inline-block;
+    border: 1px solid #000;
+    padding: 4px;
+    border-radius: 4px;
+    cursor: pointer;
+
+    &.unsaved {
+        background-color: #fff;
+    }
+    &.saved {
+        background-color: #efe;
+        cursor: default;
+    }
+    &.updated {
+        background-color: #eef;
+    }
+}
+
+@media only screen and (max-width: 900px) {
+    #mobile-upload {
+        display: block;
+    }
+
+    #desktop-upload {
+        display: none;
+    }
+}

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -1,6 +1,8 @@
 import { html } from "lit-html";
 import { repeat } from "lit-html/directives/repeat";
 import { actions } from "../../reducers/toolbar";
+import { savePlanToDB } from "../../routes";
+import { renderSaveModal } from "../../components/Modal";
 import Tabs from "../Tabs";
 import OptionsContainer from "./OptionsContainer";
 
@@ -42,8 +44,26 @@ export default class Toolbar {
         this.toolsById[tool.id] = tool;
         this.tools.push(tool);
     }
+    savePlan(e) {
+        renderSaveModal(this.state, savePlanToDB)
+        let btn = e.target;
+        btn.innerText = "Saved";
+        btn.className = "saved";
+    }
+    unsave() {
+        let btn = document.getElementById("desktop-upload");
+        // only need to update the button if user previously saved state
+        // and we now need to allow an update
+        if (btn.innerText === "Saved") {
+            btn.innerText = "Update";
+            btn.className = "updated";
+        }
+    }
     setMenuItems(menuItems) {
         this.menuItems = menuItems;
+    }
+    setState(state) {
+        this.state = state;
     }
     render() {
         const { dropdownMenuOpen } = this.store.state.toolbar;
@@ -57,6 +77,13 @@ export default class Toolbar {
                             tool => tool.id,
                             tool => tool.render(this.selectTool)
                         )}
+                    </div>
+                    <div
+                        id="desktop-upload"
+                        class="unsaved"
+                        @click="${this.savePlan.bind(this)}"
+                    >
+                        Share
                     </div>
                     ${DropdownMenuButton(dropdownMenuOpen, this.store.dispatch)}
                 </div>
@@ -102,7 +129,11 @@ function DropdownMenu(options, open) {
             ${options.map(
                 option =>
                     html`
-                        <li class="ui-list__item" @click=${option.onClick}>
+                        <li
+                            id="${option.id || ""}"
+                            class="ui-list__item"
+                            @click=${option.onClick}
+                        >
                             ${option.name}
                         </li>
                     `

--- a/src/lambda/eventRead.js
+++ b/src/lambda/eventRead.js
@@ -8,6 +8,7 @@ exports.handler = async (event, context) => {
 
   try {
     const eventCode = event.queryStringParameters.event;
+    const myHost = event.queryStringParameters.hostname;
     if (!eventCode.trim().length) {
         return {
             statusCode: 301,
@@ -17,7 +18,10 @@ exports.handler = async (event, context) => {
         };
     }
 
-    const plans = await Plan.find({ eventCode: eventCode });
+    const plans = await Plan.find({
+        eventCode: eventCode,
+        hostname: myHost
+    });
     return {
         statusCode: 200,
         body: JSON.stringify({

--- a/src/lambda/planCreate.js
+++ b/src/lambda/planCreate.js
@@ -11,7 +11,8 @@ exports.handler = async (event, context) => {
           plan = {
               _id: mongoose.Types.ObjectId(),
               plan: data.plan,
-              eventCode: data.eventCode
+              eventCode: data.eventCode,
+              hostname: data.hostname
           };
 
       await Plan.create(plan)

--- a/src/lambda/planModel.js
+++ b/src/lambda/planModel.js
@@ -7,7 +7,11 @@ const schema = new mongoose.Schema({
   eventCode: {
     type: String,
     max: 50
-  }
+  },
+  hostname: {
+    type: String,
+    max: 100
+  },
   // name: {
   //   type: String,
   //   required: [true, 'Name field is required'],

--- a/src/lambda/planRead.js
+++ b/src/lambda/planRead.js
@@ -7,8 +7,14 @@ exports.handler = async (event, context) => {
   context.callbackWaitsForEmptyEventLoop = false
 
   try {
-    const findID = event.queryStringParameters._id;
-    const plan = await Plan.findOne({ _id: findID });
+    let search = { _id: event.queryStringParameters._id },
+        myHost = event.queryStringParameters.hostname;
+    if (myHost) {
+        // optional: limit search to prod or test plans
+        // by default search all plans
+        search.hostname = myHost;
+    }
+    const plan = await Plan.findOne(search);
 
     return {
         statusCode: 200,

--- a/src/routes.js
+++ b/src/routes.js
@@ -46,6 +46,28 @@ export function savePlanToStorage({
     localStorage.setItem("savedState", JSON.stringify(state));
 }
 
+export function savePlanToDB(state, eventCode, callback) {
+    const serialized = state.serialize();
+    fetch("/.netlify/functions/planCreate", {
+        method: "POST",
+        body: JSON.stringify({
+            plan: serialized,
+            eventCode: eventCode,
+            hostname: window.location.hostname
+        })
+    })
+    .then(res => res.json())
+    .then(info => {
+        if (info._id) {
+            history.pushState({}, "Districtr", `/edit/${info._id}`);
+            callback(info._id);
+        } else {
+            callback(null);
+        }
+    })
+    .catch(e => callback(null));
+}
+
 export function getContextFromStorage() {
     const savedState = localStorage.getItem("savedState");
     let state;


### PR DESCRIPTION
The 'share plan' feature is currently inside the dropdown menu. This adds a more visible 'Share' button for desktop users:

![Screen Shot 2019-10-15 at 9 11 46 PM](https://user-images.githubusercontent.com/643918/66847187-9673a080-ef90-11e9-8ecc-62452d1c1121.png)

Clicking the button saves the plan and opens up this popup/tooltip window:

![Screen Shot 2019-10-15 at 9 11 52 PM](https://user-images.githubusercontent.com/643918/66847285-c622a880-ef90-11e9-965d-7da825733f9a.png)

Clicking the [x] closes the window (I feel like there should be more ways to close this window? How do you think we should handle this?)

The green [Saved] appears until you make more map changes. Then the button changes to 'Update' to save your updated plan:

![Screen Shot 2019-10-15 at 9 12 07 PM](https://user-images.githubusercontent.com/643918/66847458-0550f980-ef91-11e9-809c-deca87173217.png)
