### PR TITLE
Load layer on map using URL

### DIFF
--- a/deploy/_redirects
+++ b/deploy/_redirects
@@ -2,3 +2,5 @@
 /new/* /new.html 200
 /user_guide /guide
 /:place/:plan /edit?url=/assets/:place-plans/:plan.json#plan
+/:place/:plan?layer=:layer /edit?url=/assets/:place-plans/:plan.json&layer=:layer#plan
+/:place/:plan?layer=:layer&ltype=:ltype /edit?url=/assets/:place-plans/:plan.json&layer=:layer&ltype=:ltype#plan

--- a/src/layers/OverlayContainer.js
+++ b/src/layers/OverlayContainer.js
@@ -33,16 +33,30 @@ export default class OverlayContainer {
                 : "Show data layer";
         }
 
-        this.visibilityToggle = toggle(toggleText, false, visible => {
+        this.changeSubgroup = this.changeSubgroup.bind(this);
+        this.render = this.render.bind(this);
+
+        if (window.location.search.includes("layer=")) {
+            let layerSelect = window.location.search.split("layer=")[1].split("&")[0].toUpperCase();
+            this.subgroups.forEach((sg, index) => {
+                if (sg.key.toUpperCase() === layerSelect) {
+                    this.changeSubgroup(index);
+                    this.overlay.show();
+
+                    if (window.location.search.includes("ltype=circle")) {
+                        this.overlay.setLayer(1);
+                    }
+                }
+            });
+        }
+
+        this.visibilityToggle = toggle(toggleText, (this._currentSubgroupIndex !== 0), visible => {
             if (visible) {
                 this.overlay.show();
             } else {
                 this.overlay.hide();
             }
         });
-
-        this.changeSubgroup = this.changeSubgroup.bind(this);
-        this.render = this.render.bind(this);
     }
     changeSubgroup(i) {
         this._currentSubgroupIndex = i;
@@ -60,7 +74,11 @@ export default class OverlayContainer {
             </div>
             ${Parameter({
                 label: "Variable:",
-                element: Select(this.subgroups, this.changeSubgroup)
+                element: Select(
+                    this.subgroups,
+                    this.changeSubgroup,
+                    this._currentSubgroupIndex
+                )
             })}
             ${Parameter({
                 label: "Display as",

--- a/src/layers/PartisanOverlayContainer.js
+++ b/src/layers/PartisanOverlayContainer.js
@@ -17,6 +17,20 @@ export default class PartisanOverlayContainer {
         this.setElection = this.setElection.bind(this);
         this.render = this.render.bind(this);
         this.toggleVisibility = this.toggleVisibility.bind(this);
+
+        if (window.location.search.includes("layer=")) {
+            let layerSelect = window.location.search.split("layer=")[1].split("&")[0].toUpperCase();
+            elections.forEach((el, index) => {
+                el.subgroups.forEach(sg => {
+                    if (sg.key.toUpperCase() === layerSelect) {
+                        this.setElection(index);
+                        if (window.location.search.includes("ltype=circle")) {
+                            this.currentElectionOverlay.setLayer(1);
+                        }
+                    }
+                });
+            });
+        }
     }
     get currentElectionOverlay() {
         return this.electionOverlays[this._currentElectionIndex];
@@ -32,7 +46,7 @@ export default class PartisanOverlayContainer {
     setElection(i) {
         this._currentElectionIndex = i;
         this.electionOverlays.forEach(overlay => overlay.hide());
-        if (this.isVisible) {
+        if (this.isVisible || !this.currentElectionOverlay.repaint) {
             this.currentElectionOverlay.show();
         } else {
             this.currentElectionOverlay.repaint();
@@ -50,7 +64,11 @@ export default class PartisanOverlayContainer {
             ${[
                 {
                     label: "Election:",
-                    element: Select(this.elections, i => this.setElection(i))
+                    element: Select(
+                        this.elections,
+                        i => this.setElection(i),
+                        this._currentElectionIndex
+                    )
                 },
                 {
                     label: "Display as",

--- a/src/views/edit.js
+++ b/src/views/edit.js
@@ -40,8 +40,8 @@ const defaultPlugins = [
 const communityIdPlugins = [ToolsPlugin, DataLayersPlugin, CommunityPlugin];
 
 function getPlanURLFromQueryParam() {
-    if (window.location.search.includes("?url=")) {
-        return window.location.search.slice("?url=".length).split('&')[0];
+    if (window.location.search.includes("url=")) {
+        return window.location.search.slice("url=".length).split('&')[0];
     } else {
         return "";
     }

--- a/src/views/edit.js
+++ b/src/views/edit.js
@@ -41,7 +41,7 @@ const communityIdPlugins = [ToolsPlugin, DataLayersPlugin, CommunityPlugin];
 
 function getPlanURLFromQueryParam() {
     if (window.location.search.includes("url=")) {
-        return window.location.search.slice("url=".length).split('&')[0];
+        return window.location.search.split("url=")[1].split('&')[0].split("#")[0];
     } else {
         return "";
     }
@@ -100,12 +100,16 @@ function loadContext(context) {
     // display shorter URL
     if (window.history && window.history.replaceState
         && getPlanURLFromQueryParam()
-        && window.location.hostname !== 'localhost'
+        // && window.location.hostname !== 'localhost'
         && window.location.hash && window.location.hash === "#plan") {
 
         let shortPlanName = getPlanURLFromQueryParam().split("/");
         shortPlanName = shortPlanName[2].replace("-plans", "") + "/"
-            + shortPlanName[3].split(".")[0];
+            + shortPlanName[3].split(".")[0]
+            + window.location.search.replace("url=" + shortPlanName.join("/"), "");
+        if (shortPlanName[shortPlanName.length - 1] === "?") {
+            shortPlanName = shortPlanName.substring(0, shortPlanName.length - 1);
+        }
         window.history.replaceState({}, "Districtr", shortPlanName);
     }
 

--- a/src/views/edit.js
+++ b/src/views/edit.js
@@ -100,7 +100,7 @@ function loadContext(context) {
     // display shorter URL
     if (window.history && window.history.replaceState
         && getPlanURLFromQueryParam()
-        // && window.location.hostname !== 'localhost'
+        && window.location.hostname !== 'localhost'
         && window.location.hash && window.location.hash === "#plan") {
 
         let shortPlanName = getPlanURLFromQueryParam().split("/");


### PR DESCRIPTION
As suggested this week, add ```layer=___``` and ```ltype=circle``` as URL options to have a map or plan open with one of our overlays displayed

Examples:
https://deploy-preview-112--districtr-web.netlify.com/edit?url=/assets/chicago-plans/current-wards.json&layer=hisp&ltype=circle
**Update** unfortunately it's proving tricky to add these to our shorter URLs, like the ones we use in Lowell

The layer name is a key used by Demographics, VAP, or an election (PRES16D and PRES16R will both show the same election). The ltype can be set to circles.