### PR TITLE
Add shortcuts to Pan / Brush / Erase / Tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7863,6 +7863,11 @@
             "integrity": "sha512-a4u9BeERWGu/S8JiWEAQcdrg9v4QArtP9keViQjGMdff20fBdd8waotXaNmODqBe6uZ3Nafi7K/ho4gCQHV3Ig==",
             "dev": true
         },
+        "hotkeys-js": {
+            "version": "3.7.2",
+            "resolved": "https://registry.npmjs.org/hotkeys-js/-/hotkeys-js-3.7.2.tgz",
+            "integrity": "sha512-LJIPBgejlklphThig2edlYUiPq3iFDHdsXftvZ0VWrpi330dRwD2YxPlzOYv0UQEatvZdgwG3ZLCfJ020ix8vQ=="
+        },
         "html-minifier": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-4.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -72,8 +72,12 @@
         "d3-scale-chromatic": "^1.5.0",
         "d3-selection": "^1.4.0",
         "d3-transition": "^1.2.0",
+<<<<<<< HEAD
         "encoding": "^0.1.12",
         "hotkeys-js": "^3.7.3",
+=======
+        "hotkeys-js": "^3.7.2",
+>>>>>>> 857511b... add hotkeys
         "lit-html": "^1.1.2",
         "mapbox-gl": "^1.3.1"
     }

--- a/package.json
+++ b/package.json
@@ -72,12 +72,8 @@
         "d3-scale-chromatic": "^1.5.0",
         "d3-selection": "^1.4.0",
         "d3-transition": "^1.2.0",
-<<<<<<< HEAD
         "encoding": "^0.1.12",
         "hotkeys-js": "^3.7.3",
-=======
-        "hotkeys-js": "^3.7.2",
->>>>>>> 857511b... add hotkeys
         "lit-html": "^1.1.2",
         "mapbox-gl": "^1.3.1"
     }

--- a/sass/components/_icon-list.scss
+++ b/sass/components/_icon-list.scss
@@ -94,10 +94,10 @@ of the whole element */
     background-color: $districtr-grey-active;
 }
 
-.icon-list__item input:focus ~ .icon-list__item__radio {
-    border-radius: 20%;
-    background-color: $districtr-grey-active;
-}
+// .icon-list__item input:focus ~ .icon-list__item__radio {
+//     border-radius: 20%;
+//     background-color: $districtr-grey-active;
+// }
 
 .icon-list__item input:checked ~ .icon-list__item__radio {
     border-radius: 50%;

--- a/src/components/Toolbar/BrushTool.js
+++ b/src/components/Toolbar/BrushTool.js
@@ -36,7 +36,7 @@ export default class BrushTool extends Tool {
             this.brush.undo();
             evt.preventDefault();
         });
-        hotkeys(`ctrl+shift+z,command+shift+z,control+shift+z`, (evt, handler) => {
+        hotkeys(`ctrl+shift+z,command+shift+z,control+shift+z,ctrl+y,command+y,control+y`, (evt, handler) => {
             // redo
             this.brush.redo();
             evt.preventDefault();

--- a/src/components/Toolbar/Tool.js
+++ b/src/components/Toolbar/Tool.js
@@ -9,6 +9,9 @@ export default class Tool {
     }
     activate() {
         this.active = true;
+        try {
+            document.getElementById(`tool-${this.id}`).checked = true;
+        } catch(e) { }
     }
     deactivate() {
         this.active = false;

--- a/src/map/Brush.js
+++ b/src/map/Brush.js
@@ -326,11 +326,19 @@ export default class Brush extends HoverWithRadius {
         this.layer.map.on("touchstart", this.onTouchStart);
         this.layer.map.on("mousedown", this.onMouseDown);
     }
+<<<<<<< HEAD
     deactivate(mouseover) {
         super.deactivate(mouseover);
         if (mouseover) {
             return;
         }
+=======
+    deactivate() {
+        this.layer.map.getCanvas().classList.remove("brush-tool");
+
+        super.deactivate();
+        this.hoverOff();
+>>>>>>> 857511b... add hotkeys
 
         this.layer.map.getCanvas().classList.remove("brush-tool");
         this.layer.map.dragPan.enable();

--- a/src/map/Brush.js
+++ b/src/map/Brush.js
@@ -326,20 +326,14 @@ export default class Brush extends HoverWithRadius {
         this.layer.map.on("touchstart", this.onTouchStart);
         this.layer.map.on("mousedown", this.onMouseDown);
     }
-<<<<<<< HEAD
+
     deactivate(mouseover) {
         super.deactivate(mouseover);
         if (mouseover) {
             return;
         }
-=======
-    deactivate() {
-        this.layer.map.getCanvas().classList.remove("brush-tool");
 
-        super.deactivate();
         this.hoverOff();
->>>>>>> 857511b... add hotkeys
-
         this.layer.map.getCanvas().classList.remove("brush-tool");
         this.layer.map.dragPan.enable();
         this.layer.map.doubleClickZoom.enable();

--- a/src/map/Tooltip.js
+++ b/src/map/Tooltip.js
@@ -23,6 +23,9 @@ export default class Tooltip extends HoverWithRadius {
     }
     deactivate() {
         super.deactivate();
+        this.hoverOff();
+        this.visible = false;
+        this.render();
     }
     onMouseMove(e) {
         super.onMouseMove(e);

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -61,10 +61,11 @@ export default function ToolsPlugin(editor) {
     toolbar.setState(state);
 
     hotkeys.filter = ({ target }) => {
-        return true;
+        return (!["INPUT", "TEXTAREA"].includes(target.tagName)
+          || (target.tagName === 'INPUT' && target.type.toLowerCase() !== 'text'));
     };
     for (let ki = 1; ki <= tools.length; ki++) {
-        hotkeys(`ctrl+${ki},control+${ki},option+${ki}`, (evt, handler) => {
+        hotkeys(`${ki},shift+${ki}`, (evt, handler) => {
             let tabNumber = (handler.key.match(/\d/)[0] * 1) - 1;
             if (tools[tabNumber]) {
                 toolbar.selectTool(tools[tabNumber].id);

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -1,3 +1,5 @@
+import hotkeys from 'hotkeys-js';
+
 import BrushTool from "../components/Toolbar/BrushTool";
 import EraserTool from "../components/Toolbar/EraserTool";
 import InspectTool from "../components/Toolbar/InspectTool";
@@ -57,6 +59,19 @@ export default function ToolsPlugin(editor) {
     toolbar.selectTool("pan");
     toolbar.setMenuItems(getMenuItems(editor.state));
     toolbar.setState(state);
+
+    hotkeys.filter = ({ target }) => {
+        return true;
+    };
+    for (let ki = 1; ki <= tools.length; ki++) {
+        hotkeys(`ctrl+${ki},control+${ki},option+${ki}`, (evt, handler) => {
+            let tabNumber = (handler.key.match(/\d/)[0] * 1) - 1;
+            if (tools[tabNumber]) {
+                toolbar.selectTool(tools[tabNumber].id);
+            }
+            evt.preventDefault();
+        });
+    }
 
     // show about modal on startup by default
     // exceptions if you last were on this map, or set 'dev' in URL

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -64,15 +64,22 @@ export default function ToolsPlugin(editor) {
         return (!["INPUT", "TEXTAREA"].includes(target.tagName)
           || (target.tagName === 'INPUT' && target.type.toLowerCase() !== 'text'));
     };
-    for (let ki = 1; ki <= tools.length; ki++) {
-        hotkeys(`${ki},shift+${ki}`, (evt, handler) => {
-            let tabNumber = (handler.key.match(/\d/)[0] * 1) - 1;
-            if (tools[tabNumber]) {
-                toolbar.selectTool(tools[tabNumber].id);
-            }
-            evt.preventDefault();
-        });
-    }
+    hotkeys("h", (evt, handler) => {
+        evt.preventDefault();
+        toolbar.selectTool("pan");
+    });
+    hotkeys("p", (evt, handler) => {
+        evt.preventDefault();
+        toolbar.selectTool("brush");
+    });
+    hotkeys("e", (evt, handler) => {
+        evt.preventDefault();
+        toolbar.selectTool("eraser");
+    });
+    hotkeys("i", (evt, handler) => {
+        evt.preventDefault();
+        toolbar.selectTool("inspect");
+    });
 
     // show about modal on startup by default
     // exceptions if you last were on this map, or set 'dev' in URL


### PR DESCRIPTION
This uses the hotkeys library to make {Ctrl / Control / Option} + {1, 2, 3, 4, 5} open up our different toolbar tools. It should work while you are working in the map, using the toolbar, etc.

The numbers attach to the tools left to right, for example our toolbar is Grab, Brush, Eraser, so Control 1, 2, 3 link to these.

Open questions about whether my implementation makes sense:
- Control 4 is Landmarks and then Control 5 is for Inspect. This is confusing on Redistricting when Landmarks isn't there
- the Mac command / ⌘ key + a number is used to switch browser tabs, so we use Control or Alt/Option keys. I am open to other commands if ⌘ is more intuitive