### PR TITLE
Fix VA: store geoids (such as 'St. Mark') without the .

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -64,7 +64,7 @@ export function savePlanToDB(state, eventCode, callback) {
         };
     fetch(saveURL, {
         method: "POST",
-        body: JSON.stringify(requestBody)
+        body: JSON.stringify(requestBody).replace(/\./g, "÷")
     })
     .then(res => res.json())
     .then(info => {
@@ -105,7 +105,7 @@ export function loadPlanFromJSON(planRecord) {
         planRecord = planRecord.plan;
     }
     return listPlaces().then(places => {
-        const place = places.find(p => p.id === planRecord.placeId);
+        const place = places.find(p => p.id.replace(/÷/g, ".") === planRecord.placeId);
         return {
             ...planRecord,
             place


### PR DESCRIPTION
On Virginia maps, the precincts have text IDs such as "St. Mark". MongoDB does not allow us to store a JSON object with "." in the key. Fortunately we can replace it with another character, and restore it when we open the map from a URL.

How I would test this:
- create a VA map with the state 100% filled in with one color and 0 leftover population
- save the map (this makes us a share URL, solving the initial problem)
- erase the map or go to a different state to reset your local map
- reopen the original map with the share URL; it should be 100% filled and have 0 leftover population