### PR TITLE
Add missing about pages

### DIFF
--- a/assets/about/little_rock/blocks.html
+++ b/assets/about/little_rock/blocks.html
@@ -1,7 +1,7 @@
 <p>
     The units you see here are <strong>census blocks</strong>. Data for this
     module were obtained from the US Census Bureau. The block shapefile for the
-    City of Lowell was downloaded from the Census
+    City of Little Rock was downloaded from the Census
     <a href="https://www.census.gov/geo/maps-data/data/tiger-line.html">TIGER/Line Shapefiles</a>. 
     Demographic information from the 2010 Decennial Census was downloaded at the 
     block level from

--- a/assets/about/little_rock/blocks.html
+++ b/assets/about/little_rock/blocks.html
@@ -1,0 +1,9 @@
+<p>
+    The units you see here are <strong>census blocks</strong>. Data for this
+    module were obtained from the US Census Bureau. The block shapefile for the
+    City of Lowell was downloaded from the Census
+    <a href="https://www.census.gov/geo/maps-data/data/tiger-line.html">TIGER/Line Shapefiles</a>. 
+    Demographic information from the 2010 Decennial Census was downloaded at the 
+    block level from
+    <a href="https://factfinder.census.gov/faces/nav/jsf/pages/index.xhtml">American FactFinder</a>.
+</p>

--- a/assets/about/minnesota/precincts.html
+++ b/assets/about/minnesota/precincts.html
@@ -1,0 +1,6 @@
+<p>
+    The units used here are <strong>precincts</strong>. The Minnesota precinct shapefiles with election results were created by the <a href="https://www.sos.state.mn.us/elections-voting/">Minnesota Secretary of State Election Division</a> and obtained from the <a href="https://www.gis.leg.mn/html/download.html">Minnesota LCC-GIS</a>. 2010 Decennial Census demographic data were downloaded from the <a href="https://api.census.gov/data/2010/dec/sf1">Census API</a>. The 2010 census block shapefile for Minnesota was downloaded from the US Census Bureau’s <a href="https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.html">TIGER/Line Shapefiles</a>.
+    The source shapefile for this module, along with additional information
+    about processing, is available for download from MGGG's GitHub organization
+    <a href="https://github.com/mggg-states/MN-shapefiles">@mggg-states</a>.
+</p>

--- a/assets/about/providence_ri/blocks.html
+++ b/assets/about/providence_ri/blocks.html
@@ -1,7 +1,7 @@
 <p>
     The units you see here are <strong>census blocks</strong>. Data for this
     module were obtained from the US Census Bureau. The block shapefile for the
-    City of Lowell was downloaded from the Census
+    City of Providence was downloaded from the Census
     <a href="https://www.census.gov/geo/maps-data/data/tiger-line.html">TIGER/Line Shapefiles</a>. 
     Demographic information from the 2010 Decennial Census was downloaded at the 
     block level from

--- a/assets/about/providence_ri/blocks.html
+++ b/assets/about/providence_ri/blocks.html
@@ -1,0 +1,9 @@
+<p>
+    The units you see here are <strong>census blocks</strong>. Data for this
+    module were obtained from the US Census Bureau. The block shapefile for the
+    City of Lowell was downloaded from the Census
+    <a href="https://www.census.gov/geo/maps-data/data/tiger-line.html">TIGER/Line Shapefiles</a>. 
+    Demographic information from the 2010 Decennial Census was downloaded at the 
+    block level from
+    <a href="https://factfinder.census.gov/faces/nav/jsf/pages/index.xhtml">American FactFinder</a>.
+</p>


### PR DESCRIPTION
- Minnesota's `precincts.html` page has all the information from mggg-states repository.
- The `blocks.html` pages for both Little Rock and Providence are both not complete.  Currently they simply state where the data came from, but not how they were processed or if they are available for download anywhere.