### PR TITLE
Work in progress: demographic layer steps and legend

### DIFF
--- a/assets/data/response.json
+++ b/assets/data/response.json
@@ -918,7 +918,8 @@
               "name": "Total population",
               "sum": 2694007,
               "min": 14,
-              "max": 12307
+              "max": 12307,
+              "breaks": [14, 1071, 1546, 2283, 3960, 12307]
             },
             "subgroups": [
               {
@@ -926,56 +927,64 @@
                 "name": "White population",
                 "sum": 853587,
                 "min": 0,
-                "max": 2753
+                "max": 2753,
+                "breaks": [0.0, 0.124, 0.335, 0.546, 0.736, 0.944]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 871069,
                 "min": 0,
-                "max": 7723
+                "max": 7723,
+                "breaks": [0.0, 0.138, 0.392, 0.656, 0.873, 0.996]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 777839,
                 "min": 0,
-                "max": 3526
+                "max": 3526,
+                "breaks": [0.0, 0.118, 0.287, 0.492, 0.735, 0.985]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 144167,
                 "min": 0,
-                "max": 2208
+                "max": 2208,
+                "breaks": [0.0, 0.041, 0.131, 0.258, 0.535, 0.951]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 3738,
                 "min": 0,
-                "max": 22
+                "max": 22,
+                "breaks": [0.0, 0.001, 0.002, 0.004, 0.008, 0.015]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 488,
                 "min": 0,
-                "max": 18
+                "max": 18,
+                "breaks": [0.0, 0.0001, 0.001, 0.003, 0.006, 0.012]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 35108,
                 "min": 0,
-                "max": 121
+                "max": 121,
+                "breaks": [0.0, 0.007, 0.014, 0.022, 0.036, 0.096]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 3885,
                 "min": 0,
-                "max": 34
+                "max": 34,
+                "breaks": [0.0, 0.001, 0.002, 0.005, 0.011, 0.026]
               }
             ]
           },
@@ -987,7 +996,8 @@
               "name": "Voting age population",
               "sum": 2072450,
               "min": 14,
-              "max": 11384
+              "max": 11384,
+              "breaks": [14, 796, 1121, 1623, 3450, 11384]
             },
             "subgroups": [
               {
@@ -995,56 +1005,64 @@
                 "name": "White voting age population",
                 "sum": 751530,
                 "min": 0,
-                "max": 2660
+                "max": 2660,
+                "breaks": [0.0, 0.129, 0.343, 0.559, 0.75, 0.968]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 642614,
                 "min": 0,
-                "max": 7441
+                "max": 7441,
+                "breaks": [0.0, 0.135, 0.391, 0.663, 0.873, 0.996]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 523480,
                 "min": 0,
-                "max": 2304
+                "max": 2304,
+                "breaks": [0.0, 0.122, 0.301, 0.505, 0.73, 0.98]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 2883,
                 "min": 0,
-                "max": 18
+                "max": 18,
+                "breaks": [0.0, 0.001, 0.002, 0.004, 0.008, 0.015]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 405,
                 "min": 0,
-                "max": 9
+                "max": 9,
+                "breaks": [0.0, 0.001, 0.002, 0.003, 0.005, 0.009]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 121987,
                 "min": 0,
-                "max": 1793
+                "max": 1793,
+                "breaks": [0.0, 0.039, 0.124, 0.252, 0.53, 0.949]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 2636,
                 "min": 0,
-                "max": 33
+                "max": 33,
+                "breaks": [0.0, 0.001, 0.003, 0.006, 0.014, 0.027]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 22923,
                 "min": 0,
-                "max": 84
+                "max": 84,
+                "breaks": [0.0, 0.007, 0.014, 0.022, 0.047, 0.105]
               }
             ]
           }
@@ -4005,7 +4023,8 @@
               "name": "Total population",
               "sum": 6727041,
               "min": 76,
-              "max": 10369
+              "max": 10369,
+              "breaks": [76, 1582, 2602, 3318, 4513, 10369]
             },
             "subgroups": [
               {
@@ -4013,49 +4032,56 @@
                 "name": "White population",
                 "sum": 5077097,
                 "min": 11,
-                "max": 8331
+                "max": 8331,
+                "breaks": [0.0266, 0.3183, 0.5665, 0.7491, 0.8772, 0.9808]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 445770,
                 "min": 0,
-                "max": 2906
+                "max": 2906,
+                "breaks": [0.0, 0.0486, 0.1301, 0.2803, 0.5028, 0.8502]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 680464,
                 "min": 0,
-                "max": 3345
+                "max": 3345,
+                "breaks": [0.0, 0.0755, 0.2013, 0.3792, 0.611, 0.9253]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 386992,
                 "min": 0,
-                "max": 4166
+                "max": 4166,
+                "breaks": [0.0, 0.0353, 0.0841, 0.1594, 0.2852, 0.5458]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 34492,
                 "min": 0,
-                "max": 205
+                "max": 205,
+                "breaks": [0.0, 0.0051, 0.011, 0.0346, 0.0692, 0.2986]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 6184,
                 "min": 0,
-                "max": 40
+                "max": 40,
+                "breaks": [0.0, 0.0005, 0.0015, 0.0028, 0.0054, 0.0109]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 89748,
                 "min": 0,
-                "max": 1077
+                "max": 1077,
+                "breaks": [0.0, 0.0128, 0.0364, 0.0723, 0.1269, 0.2004]
               }
             ]
           },
@@ -4067,7 +4093,8 @@
               "name": "Voting age population",
               "sum": 5123060,
               "min": 62,
-              "max": 8063
+              "max": 8063,
+              "breaks": [62.0, 1260, 2082, 2626, 3699, 8063]
             },
             "subgroups": [
               {
@@ -4075,56 +4102,64 @@
                 "name": "White voting age population",
                 "sum": 4024314,
                 "min": 3,
-                "max": 6632
+                "max": 6632,
+                "breaks": [0.0271, 0.3556, 0.6102, 0.7816, 0.8984, 0.9887]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 287367,
                 "min": 0,
-                "max": 2030
+                "max": 2030,
+                "breaks": [0.0, 0.0463, 0.1406, 0.3004, 0.5821, 0.8637]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 415465,
                 "min": 0,
-                "max": 2098
+                "max": 2098,
+                "breaks": [0.0, 0.0588, 0.1685, 0.3456, 0.6097, 0.911]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 7229,
                 "min": 0,
-                "max": 126
+                "max": 126,
+                "breaks": [0.0, 0.0016, 0.0051, 0.0231, 0.0543, 0.253]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 810,
                 "min": 0,
-                "max": 9
+                "max": 9,
+                "breaks": [0.0, 0.0002, 0.0006, 0.0011, 0.0019, 0.0036]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 267838,
                 "min": 0,
-                "max": 3594
+                "max": 3594,
+                "breaks": [0.0, 0.0308, 0.0796, 0.1565, 0.291, 0.5333]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 44891,
                 "min": 0,
-                "max": 562
+                "max": 562,
+                "breaks": [0.0, 0.0082, 0.025, 0.0491, 0.0888, 0.173]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 68414,
                 "min": 0,
-                "max": 311
+                "max": 311,
+                "breaks": [0.0, 0.0091, 0.0164, 0.0274, 0.0502, 0.1014]
               }
             ]
           },

--- a/assets/data/response.json
+++ b/assets/data/response.json
@@ -14,7 +14,8 @@
               "name": "Total population",
               "sum": 710231,
               "min": 44,
-              "max": 7994
+              "max": 7994,
+              "breaks": [44, 877, 1888, 2941, 4453, 7994]
             },
             "subgroups": [
               {
@@ -22,49 +23,56 @@
                 "name": "White population",
                 "sum": 473576,
                 "min": 1,
-                "max": 5953
+                "max": 5953,
+                "breaks": [0.0096, 0.1693, 0.3769, 0.5762, 0.7534, 0.9644]
               },
               {
                 "key": "BLACK",
                 "name": "Black population",
                 "sum": 23263,
                 "min": 0,
-                "max": 980
+                "max": 980,
+                "breaks": [0.0, 0.016, 0.0437, 0.0759, 0.1096, 0.1792]
               },
               {
                 "key": "ASIAN",
                 "name": "Asian population",
                 "sum": 38135,
                 "min": 0,
-                "max": 1452
+                "max": 1452,
+                "breaks": [0.0, 0.0195, 0.0573, 0.1189, 0.217, 0.4516]
               },
               {
                 "key": "AMIN",
                 "name": "Native American and Alaskan Native population",
                 "sum": 104871,
                 "min": 0,
-                "max": 2428
+                "max": 2428,
+                "breaks": [0.0, 0.0959, 0.249, 0.5106, 0.8, 0.9854]
               },
               {
                 "key": "NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 7409,
                 "min": 0,
-                "max": 428
+                "max": 428,
+                "breaks": [0.0, 0.005, 0.0162, 0.0337, 0.0589, 0.1046]
               },
               {
                 "key": "2MORE",
                 "name": "Two or more races",
                 "sum": 51875,
                 "min": 0,
-                "max": 499
+                "max": 499,
+                "breaks": [0.0, 0.0316, 0.0632, 0.0956, 0.1679, 0.2593]
               },
               {
                 "key": "OTHER",
                 "name": "Other races",
                 "sum": 11102,
                 "min": 0,
-                "max": 364
+                "max": 364,
+                "breaks": [0.0, 0.005, 0.0136, 0.0262, 0.0477, 0.093]
               }
             ]
           },
@@ -76,7 +84,8 @@
               "name": "Voting age population",
               "sum": 522853,
               "min": 31,
-              "max": 5372
+              "max": 5372,
+              "breaks": [31, 611, 1316, 2019, 3072, 5372]
             },
             "subgroups": [
               {
@@ -84,49 +93,56 @@
                 "name": "White voting age population",
                 "sum": 368895,
                 "min": 1,
-                "max": 4122
+                "max": 4122,
+                "breaks": [0.0137, 0.1753, 0.3984, 0.6193, 0.7896, 0.957]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 16904,
                 "min": 0,
-                "max": 645
+                "max": 645,
+                "breaks": [0.0, 0.0161, 0.0434, 0.0768, 0.1145, 0.1822]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 70630,
                 "min": 0,
-                "max": 1528
+                "max": 1528,
+                "breaks": [0.0, 0.0954, 0.2589, 0.5415, 0.7879, 0.9859]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 4599,
                 "min": 0,
-                "max": 228
+                "max": 228,
+                "breaks": [0.0, 0.0038, 0.0129, 0.0278, 0.0511, 0.088]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 28312,
                 "min": 0,
-                "max": 1245
+                "max": 1245,
+                "breaks": [0.0, 0.0206, 0.0587, 0.1159, 0.2022, 0.4405]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 7988,
                 "min": 0,
-                "max": 304
+                "max": 304,
+                "breaks": [0.0, 0.0041, 0.0119, 0.0245, 0.0426, 0.0826]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 25525,
                 "min": 0,
-                "max": 257
+                "max": 257,
+                "breaks": [0.0, 0.0238, 0.0462, 0.0687, 0.107, 0.1909]
               }
             ]
           },
@@ -311,7 +327,8 @@
               "name": "Total Population",
               "sum": 819569,
               "min": 0,
-              "max": 3406
+              "max": 3406,
+              "breaks": [0, 96, 360, 823, 1536, 3406]
             },
             "subgroups": [
               {
@@ -319,42 +336,48 @@
                 "name": "White population",
                 "sum": 400469,
                 "min": 0,
-                "max": 2066
+                "max": 2066,
+                "breaks": [0.0, 0.1222, 0.3571, 0.5902, 0.8, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 64131,
                 "min": 0,
-                "max": 555
+                "max": 555,
+                "breaks": [0.0, 0.0448, 0.1553, 0.3465, 0.6531, 1.0]
               },
               {
                 "key": "HPOP",
                 "name": "Hispanic population",
                 "sum": 285769,
                 "min": 0,
-                "max": 1635
+                "max": 1635,
+                "breaks": [0.0, 0.0795, 0.2414, 0.4552, 0.7014, 1.0]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 50995,
                 "min": 0,
-                "max": 795
+                "max": 795,
+                "breaks": [0.0, 0.0411, 0.1389, 0.3, 0.5375, 1.0]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 2074,
                 "min": 0,
-                "max": 13
+                "max": 13,
+                "breaks": [0.0, 0.013, 0.0602, 0.125, 0.2727, 0.5]
               },
               {
                 "key": "NH_NAHI",
                 "name": "Hawaiian Native population",
                 "sum": 432,
                 "min": 0,
-                "max": 12
+                "max": 12,
+                "breaks": [0.0, 0.0081, 0.0312, 0.069, 0.125, 0.25]
               }
             ]
           }
@@ -1113,7 +1136,8 @@
               "name": "Total population",
               "sum": 2695015,
               "min": 2917,
-              "max": 98503
+              "max": 98503,
+              "breaks": [2917, 15639, 26471, 45392, 64133, 98503]
             },
             "subgroups": [
               {
@@ -1121,56 +1145,64 @@
                 "name": "White population",
                 "sum": 854489,
                 "min": 19,
-                "max": 75836
+                "max": 75836,
+                "breaks": [0.0027, 0.0812, 0.215, 0.449, 0.6308, 0.8836]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 871967,
                 "min": 28,
-                "max": 83836
+                "max": 83836,
+                "breaks": [0.0025, 0.1434, 0.3425, 0.4926, 0.7467, 0.9778]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 778787,
                 "min": 20,
-                "max": 65461
+                "max": 65461,
+                "breaks": [0.0069, 0.12, 0.2907, 0.456, 0.6468, 0.8921]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 144844,
                 "min": 0,
-                "max": 16182
+                "max": 16182,
+                "breaks": [0.0, 0.0304, 0.0886, 0.1592, 0.345, 0.7253]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 4060,
                 "min": 0,
-                "max": 190
+                "max": 190,
+                "breaks": [0.0, 0.0007, 0.0013, 0.0019, 0.0026, 0.0034]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 543,
                 "min": 0,
-                "max": 43
+                "max": 43,
+                "breaks": [0.0, 0.0001, 0.0002, 0.0003, 0.0005, 0.0009]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 35899,
                 "min": 26,
-                "max": 1918
+                "max": 1918,
+                "breaks": [0.0016, 0.0059, 0.0123, 0.0186, 0.027, 0.0363]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 4195,
                 "min": 0,
-                "max": 224
+                "max": 224,
+                "breaks": [0.0, 0.0007, 0.0012, 0.002, 0.0028, 0.0038]
               }
             ]
           },
@@ -1182,7 +1214,8 @@
               "name": "Voting age population",
               "sum": 2073463,
               "min": 2121,
-              "max": 85746
+              "max": 85746,
+              "breaks": [2121, 17463, 29936, 44494, 57549, 85746]
             },
             "subgroups": [
               {
@@ -1190,56 +1223,64 @@
                 "name": "White voting age population",
                 "sum": 752425,
                 "min": 18,
-                "max": 69746
+                "max": 69746,
+                "breaks": [0.0033, 0.113, 0.2982, 0.4993, 0.662, 0.9003]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 643519,
                 "min": 20,
-                "max": 60990
+                "max": 60990,
+                "breaks": [0.0023, 0.1409, 0.3474, 0.5083, 0.7432, 0.9785]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 524414,
                 "min": 11,
-                "max": 43193
+                "max": 43193,
+                "breaks": [0.0052, 0.1021, 0.2553, 0.4584, 0.5989, 0.8664]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 3184,
                 "min": 0,
-                "max": 171
+                "max": 171,
+                "breaks": [0.0, 0.0005, 0.0012, 0.0019, 0.0025, 0.0035]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 457,
                 "min": 0,
-                "max": 42
+                "max": 42,
+                "breaks": [0.0, 0.0001, 0.0002, 0.0003, 0.0006, 0.0011]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 122664,
                 "min": 0,
-                "max": 12215
+                "max": 12215,
+                "breaks": [0.0, 0.0292, 0.0872, 0.1679, 0.3482, 0.7252]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 2906,
                 "min": 0,
-                "max": 165
+                "max": 165,
+                "breaks": [0.0, 0.0004, 0.0011, 0.0018, 0.0025, 0.0033]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 23666,
                 "min": 20,
-                "max": 1235
+                "max": 1235,
+                "breaks": [0.0017, 0.0054, 0.0101, 0.0155, 0.0226, 0.0283]
               }
             ]
           }
@@ -1323,7 +1364,8 @@
               "name": "Total population",
               "sum": 5027604,
               "min": 0,
-              "max": 13812
+              "max": 13812,
+              "breaks": [0, 1031, 1859, 2908, 6691, 13812]
             },
             "subgroups": [
               {
@@ -1331,56 +1373,64 @@
                 "name": "White population",
                 "sum": 3519213,
                 "min": 0,
-                "max": 9078
+                "max": 9078,
+                "breaks": [0.0, 0.332, 0.553, 0.7236, 0.8487, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 187370,
                 "min": 0,
-                "max": 1512
+                "max": 1512,
+                "breaks": [0.0, 0.0384, 0.1105, 0.2182, 0.3731, 0.5661]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 1037160,
                 "min": 0,
-                "max": 3735
+                "max": 3735,
+                "breaks": [0.0, 0.1082, 0.2264, 0.3885, 0.5785, 0.9073]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 134096,
                 "min": 0,
-                "max": 990
+                "max": 990,
+                "breaks": [0.0, 0.0168, 0.0394, 0.0718, 0.1262, 0.2867]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 29840,
                 "min": 0,
-                "max": 1367
+                "max": 1367,
+                "breaks": [0.0, 0.0063, 0.0273, 0.0939, 0.2534, 0.9126]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 4900,
                 "min": 0,
-                "max": 129
+                "max": 129,
+                "breaks": [0.0, 0.0007, 0.0025, 0.0056, 0.0101, 0.0207]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 99318,
                 "min": 0,
-                "max": 551
+                "max": 551,
+                "breaks": [0.0, 0.0126, 0.0228, 0.0365, 0.0847, 0.3333]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 6621,
                 "min": 0,
-                "max": 26
+                "max": 26,
+                "breaks": [0.0, 0.0013, 0.0042, 0.0111, 0.0291, 0.0615]
               }
             ]
           },
@@ -1392,7 +1442,8 @@
               "name": "Voting age population",
               "sum": 3802040,
               "min": 0,
-              "max": 9838
+              "max": 9838,
+              "breaks": [0, 766, 1369, 2131, 4796, 9838]
             },
             "subgroups": [
               {
@@ -1400,56 +1451,64 @@
                 "name": "White voting age population",
                 "sum": 2808959,
                 "min": 0,
-                "max": 6759
+                "max": 6759,
+                "breaks": [0.0, 0.3445, 0.5711, 0.7401, 0.8595, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 137437,
                 "min": 0,
-                "max": 1108
+                "max": 1108,
+                "breaks": [0.0, 0.0425, 0.126, 0.248, 0.4097, 0.6106]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 662933,
                 "min": 0,
-                "max": 2294
+                "max": 2294,
+                "breaks": [0.0, 0.0936, 0.1975, 0.3471, 0.5368, 0.9038]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 22560,
                 "min": 0,
-                "max": 907
+                "max": 907,
+                "breaks": [0.0, 0.0055, 0.0191, 0.0759, 0.2507, 0.9217]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 3376,
                 "min": 0,
-                "max": 82
+                "max": 82,
+                "breaks": [0.0, 0.0007, 0.0023, 0.0055, 0.0114, 0.0252]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 101885,
                 "min": 0,
-                "max": 619
+                "max": 619,
+                "breaks": [0.0, 0.0167, 0.0391, 0.0705, 0.121, 0.2703]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 3924,
                 "min": 0,
-                "max": 16
+                "max": 16,
+                "breaks": [0.0, 0.0006, 0.0021, 0.0044, 0.0101, 0.0222]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 52039,
                 "min": 0,
-                "max": 306
+                "max": 306,
+                "breaks": [0.0, 0.0086, 0.0159, 0.0255, 0.0698, 0.3333]
               }
             ]
           },
@@ -1740,7 +1799,8 @@
               "name": "Total population",
               "sum": 3046355,
               "min": 4029,
-              "max": 430640
+              "max": 430640,
+              "breaks": [4029, 26306, 66135, 131090, 211226, 430640]
             },
             "subgroups": [
               {
@@ -1748,49 +1808,56 @@
                 "name": "White population",
                 "sum": 2701123,
                 "min": 3922,
-                "max": 347710
+                "max": 347710,
+                "breaks": [0.679, 0.7336, 0.8389, 0.9046, 0.9506, 0.9817]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 86906,
                 "min": 7,
-                "max": 25344
+                "max": 25344,
+                "breaks": [0.0008, 0.0077, 0.0176, 0.0305, 0.0589, 0.0877]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 151544,
                 "min": 37,
-                "max": 32647
+                "max": 32647,
+                "breaks": [0.006, 0.0286, 0.0614, 0.1132, 0.1726, 0.2416]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 52597,
                 "min": 12,
-                "max": 15118
+                "max": 15118,
+                "breaks": [0.0014, 0.0063, 0.0135, 0.0351, 0.06, 0.0843]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 8581,
                 "min": 4,
-                "max": 1789
+                "max": 1789,
+                "breaks": [0.0003, 0.0018, 0.0045, 0.0097, 0.0175, 0.0666]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 1797,
                 "min": 0,
-                "max": 282
+                "max": 282,
+                "breaks": [0.0, 0.0003, 0.0008, 0.0019, 0.0032, 0.0047]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 2132,
                 "min": 0,
-                "max": 605
+                "max": 605,
+                "breaks": [0.0, 0.0002, 0.0005, 0.0007, 0.0011, 0.0018]
               }
             ]
           },
@@ -1802,7 +1869,8 @@
               "name": "Voting age population",
               "sum": 2318362,
               "min": 3180,
-              "max": 320715
+              "max": 320715,
+              "breaks": [3180, 20027, 46914, 104964, 159379, 320715]
             },
             "subgroups": [
               {
@@ -1810,56 +1878,64 @@
                 "name": "White voting age population",
                 "sum": 2107975,
                 "min": 3109,
-                "max": 269979
+                "max": 269979,
+                "breaks": [0.7349, 0.7924, 0.8781, 0.9282, 0.9601, 0.9888]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 57064,
                 "min": 3,
-                "max": 16507
+                "max": 16507,
+                "breaks": [0.0005, 0.0063, 0.0144, 0.0233, 0.0396, 0.0748]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 88337,
                 "min": 22,
-                "max": 19054
+                "max": 19054,
+                "breaks": [0.0052, 0.0246, 0.0518, 0.0862, 0.1256, 0.1866]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 6038,
                 "min": 2,
-                "max": 1167
+                "max": 1167,
+                "breaks": [0.0002, 0.0016, 0.0036, 0.0067, 0.0156, 0.0602]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 1181,
                 "min": 0,
-                "max": 169
+                "max": 169,
+                "breaks": [0.0, 0.0003, 0.0006, 0.0014, 0.0024, 0.0042]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 39569,
                 "min": 9,
-                "max": 10912
+                "max": 10912,
+                "breaks": [0.0014, 0.0063, 0.0146, 0.034, 0.0631, 0.0979]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 1057,
                 "min": 0,
-                "max": 273
+                "max": 273,
+                "breaks": [0.0, 0.0001, 0.0003, 0.0005, 0.0009, 0.0014]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 17141,
                 "min": 11,
-                "max": 3167
+                "max": 3167,
+                "breaks": [0.0018, 0.0032, 0.0046, 0.0067, 0.0091, 0.012]
               }
             ]
           }
@@ -1926,7 +2002,8 @@
               "name": "Total population",
               "sum": 9687653,
               "min": 0,
-              "max": 44065
+              "max": 44065,
+              "breaks": [0, 2546, 5010, 8855, 17984, 44065]
             },
             "subgroups": [
               {
@@ -1934,56 +2011,64 @@
                 "name": "White population",
                 "sum": 5413920,
                 "min": 0,
-                "max": 27519
+                "max": 27519,
+                "breaks": [0.0, 0.1953, 0.4291, 0.6361, 0.8122, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 2910800,
                 "min": 0,
-                "max": 21054
+                "max": 21054,
+                "breaks": [0.0, 0.129, 0.2905, 0.4931, 0.7362, 1.0]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 853689,
                 "min": 0,
-                "max": 9354
+                "max": 9354,
+                "breaks": [0.0, 0.0525, 0.1272, 0.2612, 0.46, 0.7392]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 311692,
                 "min": 0,
-                "max": 3514
+                "max": 3514,
+                "breaks": [0.0, 0.0248, 0.0719, 0.1464, 0.2625, 0.4399]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 21279,
                 "min": 0,
-                "max": 167
+                "max": 167,
+                "breaks": [0.0, 0.0014, 0.0031, 0.006, 0.0141, 0.0323]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 5152,
                 "min": 0,
-                "max": 74
+                "max": 74,
+                "breaks": [0.0, 0.0004, 0.0013, 0.003, 0.006, 0.0127]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 151980,
                 "min": 0,
-                "max": 677
+                "max": 677,
+                "breaks": [0.0, 0.0082, 0.0138, 0.0197, 0.0282, 0.0769]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 19141,
                 "min": 0,
-                "max": 160
+                "max": 160,
+                "breaks": [0.0, 0.0009, 0.0025, 0.0048, 0.0115, 0.0239]
               }
             ]
           },
@@ -1995,7 +2080,8 @@
               "name": "Voting age population",
               "sum": 7196101,
               "min": 0,
-              "max": 34169
+              "max": 34169,
+              "breaks": [0, 1910, 3727, 6583, 14427, 34169]
             },
             "subgroups": [
               {
@@ -2003,56 +2089,64 @@
                 "name": "White voting age population",
                 "sum": 4242514,
                 "min": 0,
-                "max": 22026
+                "max": 22026,
+                "breaks": [0.0, 0.2053, 0.4446, 0.6505, 0.8224, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 2072946,
                 "min": 0,
-                "max": 14934
+                "max": 14934,
+                "breaks": [0.0, 0.1236, 0.2799, 0.4778, 0.7343, 1.0]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 539002,
                 "min": 0,
-                "max": 5586
+                "max": 5586,
+                "breaks": [0.0, 0.0463, 0.1121, 0.2295, 0.4119, 0.6938]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 16324,
                 "min": 0,
-                "max": 145
+                "max": 145,
+                "breaks": [0.0, 0.0015, 0.0031, 0.0057, 0.0117, 0.0312]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 3699,
                 "min": 0,
-                "max": 49
+                "max": 49,
+                "breaks": [0.0, 0.0003, 0.001, 0.0022, 0.0046, 0.0094]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 234164,
                 "min": 0,
-                "max": 2443
+                "max": 2443,
+                "breaks": [0.0, 0.0241, 0.0677, 0.1354, 0.2375, 0.4276]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 10107,
                 "min": 0,
-                "max": 124
+                "max": 124,
+                "breaks": [0.0, 0.0009, 0.0024, 0.005, 0.0118, 0.023]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 77345,
                 "min": 0,
-                "max": 383
+                "max": 383,
+                "breaks": [0.0, 0.0067, 0.0119, 0.0188, 0.0451, 0.0909]
               }
             ]
           },
@@ -2163,7 +2257,8 @@
               "name": "Total Population",
               "sum": 335542,
               "min": 0,
-              "max": 1526
+              "max": 1526,
+              "breaks": [0, 44, 123, 273, 613, 1526]
             },
             "subgroups": [
               {
@@ -2171,42 +2266,48 @@
                 "name": "White population",
                 "sum": 195282,
                 "min": 0,
-                "max": 1303
+                "max": 1303,
+                "breaks": [0.0, 0.1212, 0.3937, 0.6892, 0.8894, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 27898,
                 "min": 0,
-                "max": 346
+                "max": 346,
+                "breaks": [0.0, 0.0526, 0.157, 0.2909, 0.5333, 1.0]
               },
               {
                 "key": "HPOP",
                 "name": "Hispanic population",
                 "sum": 97371,
                 "min": 0,
-                "max": 647
+                "max": 647,
+                "breaks": [0.0, 0.0824, 0.2812, 0.5263, 0.7414, 1.0]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 9358,
                 "min": 0,
-                "max": 172
+                "max": 172,
+                "breaks": [0.0, 0.0351, 0.127, 0.32, 0.5714, 1.0]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 520,
                 "min": 0,
-                "max": 15
+                "max": 15,
+                "breaks": [0.0, 0.0105, 0.0455, 0.1, 0.1765, 0.2381]
               },
               {
                 "key": "NH_NAHI",
                 "name": "Hawaiian Native population",
                 "sum": 52,
                 "min": 0,
-                "max": 7
+                "max": 7,
+                "breaks": [0.0, 0.0051, 0.02, 0.0411, 0.0565, 0.12]
               }
             ]
           }
@@ -2631,7 +2732,8 @@
               "name": "Total Population",
               "sum": 106519,
               "min": 0,
-              "max": 1469
+              "max": 1469,
+              "breaks": [0, 49, 146, 324, 623, 1469]
             },
             "subgroups": [
               {
@@ -2639,35 +2741,40 @@
                 "name": "White population",
                 "sum": 56280,
                 "min": 0,
-                "max": 793
+                "max": 793,
+                "breaks": [0.0, 0.1565, 0.4259, 0.6452, 0.8519, 1.0]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 18396,
                 "min": 0,
-                "max": 330
+                "max": 330,
+                "breaks": [0.0, 0.0588, 0.1787, 0.3462, 0.6087, 1.0]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 22459,
                 "min": 0,
-                "max": 316
+                "max": 316,
+                "breaks": [0.0, 0.0673, 0.2109, 0.3895, 0.625, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black Population",
                 "sum": 6367,
                 "min": 0,
-                "max": 200
+                "max": 200,
+                "breaks": [0.0, 0.0339, 0.1091, 0.2308, 0.4545, 1.0]
               },
               {
                 "key": "COALTNPOP",
                 "name": "Coalition population",
                 "sum": 40855,
                 "min": 0,
-                "max": 607
+                "max": 607,
+                "breaks": [0.0, 0.0976, 0.2812, 0.4762, 0.6977, 1.0]
               }
             ]
           },
@@ -2679,7 +2786,8 @@
               "name": "Voting age population",
               "sum": 81259,
               "min": 0,
-              "max": 1120
+              "max": 1120,
+              "breaks": [0, 35, 107, 246, 551, 1120]
             },
             "subgroups": [
               {
@@ -2687,35 +2795,40 @@
                 "name": "White voting age population",
                 "sum": 47187,
                 "min": 0,
-                "max": 751
+                "max": 751,
+                "breaks": [0.0, 0.15, 0.403, 0.6154, 0.8261, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 4515,
                 "min": 0,
-                "max": 106
+                "max": 106,
+                "breaks": [0.0, 0.0333, 0.1095, 0.2353, 0.5455, 1.0]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 11600,
                 "min": 0,
-                "max": 192
+                "max": 192,
+                "breaks": [0.0, 0.0617, 0.1835, 0.3413, 0.5882, 1.0]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 15270,
                 "min": 0,
-                "max": 207
+                "max": 207,
+                "breaks": [0.0, 0.0682, 0.2072, 0.3846, 0.6037, 1.0]
               },
               {
                 "key": "COALTNVAP",
                 "name": "Coalition voting age population",
                 "sum": 26870,
                 "min": 0,
-                "max": 379
+                "max": 379,
+                "breaks": [0.0, 0.08, 0.2448, 0.4286, 0.6591, 1.0]
               }
             ]
           }
@@ -2772,7 +2885,8 @@
               "name": "Total population",
               "sum": 5773552,
               "min": 0,
-              "max": 14983
+              "max": 14983,
+              "breaks": [0, 1685, 2975, 4340, 6400, 14983]
             },
             "subgroups": [
               {
@@ -2780,56 +2894,64 @@
                 "name": "White population",
                 "sum": 3157958,
                 "min": 0,
-                "max": 8981
+                "max": 8981,
+                "breaks": [0.0, 0.1946, 0.4332, 0.6426, 0.8207, 0.993]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 1674229,
                 "min": 0,
-                "max": 7159
+                "max": 7159,
+                "breaks": [0.0, 0.1081, 0.2631, 0.4837, 0.751, 0.983]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 470632,
                 "min": 0,
-                "max": 12364
+                "max": 12364,
+                "breaks": [0.0, 0.0576, 0.1575, 0.3066, 0.4979, 0.8252]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 316694,
                 "min": 0,
-                "max": 3224
+                "max": 3224,
+                "breaks": [0.0, 0.0309, 0.0757, 0.1386, 0.2341, 0.485]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 13815,
                 "min": 0,
-                "max": 78
+                "max": 78,
+                "breaks": [0.0, 0.0023, 0.0058, 0.0137, 0.037, 0.0685]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 2412,
                 "min": 0,
-                "max": 35
+                "max": 35,
+                "breaks": [0.0, 0.0002, 0.0008, 0.0017, 0.004, 0.0078]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 125840,
                 "min": 0,
-                "max": 511
+                "max": 511,
+                "breaks": [0.0, 0.0115, 0.0189, 0.0272, 0.0376, 0.0718]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 11972,
                 "min": 0,
-                "max": 119
+                "max": 119,
+                "breaks": [0.0, 0.0009, 0.0023, 0.004, 0.0064, 0.0122]
               }
             ]
           },
@@ -2841,7 +2963,8 @@
               "name": "Voting age population",
               "sum": 4420588,
               "min": 0,
-              "max": 11788
+              "max": 11788,
+              "breaks": [0, 1267, 2219, 3219, 4824, 11788]
             },
             "subgroups": [
               {
@@ -2849,56 +2972,64 @@
                 "name": "White voting age population",
                 "sum": 2529506,
                 "min": 0,
-                "max": 6779
+                "max": 6779,
+                "breaks": [0.0, 0.2081, 0.456, 0.6631, 0.8368, 0.9952]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 1239796,
                 "min": 0,
-                "max": 5345
+                "max": 5345,
+                "breaks": [0.0, 0.1048, 0.2555, 0.4718, 0.7429, 0.9815]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 322308,
                 "min": 0,
-                "max": 9698
+                "max": 9698,
+                "breaks": [0.0, 0.0499, 0.1372, 0.2754, 0.4563, 0.8227]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 10722,
                 "min": 0,
-                "max": 70
+                "max": 70,
+                "breaks": [0.0, 0.002, 0.0049, 0.0105, 0.0236, 0.0714]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 1937,
                 "min": 0,
-                "max": 25
+                "max": 25,
+                "breaks": [0.0, 0.0002, 0.0008, 0.0016, 0.0034, 0.0069]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 245537,
                 "min": 0,
-                "max": 2214
+                "max": 2214,
+                "breaks": [0.0, 0.0321, 0.0796, 0.1452, 0.2495, 0.4841]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 6928,
                 "min": 0,
-                "max": 119
+                "max": 119,
+                "breaks": [0.0, 0.0007, 0.0019, 0.0033, 0.0055, 0.0117]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 63854,
                 "min": 0,
-                "max": 316
+                "max": 316,
+                "breaks": [0.0, 0.0077, 0.0125, 0.0173, 0.0236, 0.0432]
               }
             ]
           },
@@ -3266,7 +3397,8 @@
               "name": "Total population",
               "sum": 6547629,
               "min": 75,
-              "max": 617594
+              "max": 617594,
+              "breaks": [75, 18272, 51251, 106519, 181045, 617594]
             },
             "subgroups": [
               {
@@ -3274,49 +3406,56 @@
                 "name": "White population",
                 "sum": 4984800,
                 "min": 72,
-                "max": 290312
+                "max": 290312,
+                "breaks": [0.2047, 0.5595, 0.7617, 0.8606, 0.9284, 0.982]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 391693,
                 "min": 0,
-                "max": 138073
+                "max": 138073,
+                "breaks": [0.0, 0.0259, 0.071, 0.1427, 0.2236, 0.3711]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 627654,
                 "min": 0,
-                "max": 107917
+                "max": 107917,
+                "breaks": [0.0, 0.0413, 0.1084, 0.2663, 0.4843, 0.738]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 347495,
                 "min": 0,
-                "max": 54846
+                "max": 54846,
+                "breaks": [0.0, 0.0191, 0.0439, 0.0783, 0.1333, 0.2398]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 10778,
                 "min": 0,
-                "max": 1227
+                "max": 1227,
+                "breaks": [0.0, 0.0013, 0.0035, 0.0103, 0.0289, 0.2637]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 1467,
                 "min": 0,
-                "max": 182
+                "max": 182,
+                "breaks": [0.0, 0.0001, 0.0003, 0.0005, 0.0011, 0.0022]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 61547,
                 "min": 0,
-                "max": 10078
+                "max": 10078,
+                "breaks": [0.0, 0.004, 0.0118, 0.0256, 0.0595, 0.0888]
               }
             ]
           },
@@ -3328,7 +3467,8 @@
               "name": "Voting age population",
               "sum": 5128706,
               "min": 64,
-              "max": 513884
+              "max": 513884,
+              "breaks": [64, 14020, 36909, 81259, 141103, 513884]
             },
             "subgroups": [
               {
@@ -3336,56 +3476,64 @@
                 "name": "White voting age population",
                 "sum": 4029458,
                 "min": 61,
-                "max": 266389
+                "max": 266389,
+                "breaks": [0.2471, 0.4847, 0.6792, 0.8288, 0.9161, 0.9887]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 288523,
                 "min": 0,
-                "max": 103642
+                "max": 103642,
+                "breaks": [0.0, 0.0208, 0.0618, 0.1323, 0.2017, 0.3419]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 416775,
                 "min": 0,
-                "max": 76708
+                "max": 76708,
+                "breaks": [0.0, 0.0337, 0.0922, 0.2197, 0.4072, 0.6951]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 8219,
                 "min": 0,
-                "max": 952
+                "max": 952,
+                "breaks": [0.0, 0.0015, 0.0036, 0.0085, 0.0262, 0.256]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 1189,
                 "min": 0,
-                "max": 157
+                "max": 157,
+                "breaks": [0.0, 0.0001, 0.0004, 0.0007, 0.0013, 0.0026]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 269089,
                 "min": 0,
-                "max": 47733
+                "max": 47733,
+                "breaks": [0.0, 0.0183, 0.0456, 0.0812, 0.1271, 0.2286]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 45871,
                 "min": 0,
-                "max": 7563
+                "max": 7563,
+                "breaks": [0.0, 0.0038, 0.0111, 0.025, 0.0466, 0.0819]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 69582,
                 "min": 0,
-                "max": 10740
+                "max": 10740,
+                "breaks": [0.0, 0.008, 0.0139, 0.0237, 0.0343, 0.056]
               }
             ]
           },
@@ -3680,7 +3828,8 @@
               "name": "Total population",
               "sum": 6349032,
               "min": 86,
-              "max": 9520
+              "max": 9520,
+              "breaks": [76, 1619, 2537, 3284, 4609, 10369]
             },
             "subgroups": [
               {
@@ -3688,49 +3837,56 @@
                 "name": "White population",
                 "sum": 5198297,
                 "min": 5,
-                "max": 8275
+                "max": 8275,
+                "breaks": [0.0075, 0.2781, 0.5173, 0.7021, 0.8577, 0.9808]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 318329,
                 "min": 0,
-                "max": 3067
+                "max": 3067,
+                "breaks": [0.0, 0.0546, 0.1459, 0.3068, 0.5439, 0.8564]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 428729,
                 "min": 0,
-                "max": 2767
+                "max": 2767,
+                "breaks": [0.0, 0.0696, 0.1788, 0.345, 0.5884, 0.9253]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 236785,
                 "min": 0,
-                "max": 3518
+                "max": 3518,
+                "breaks": [0.0, 0.0377, 0.0876, 0.1618, 0.2965, 0.546]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 11264,
                 "min": 0,
-                "max": 162
+                "max": 162,
+                "breaks": [0.0, 0.0052, 0.0109, 0.0349, 0.0695, 0.3009]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 1706,
                 "min": 0,
-                "max": 19
+                "max": 19,
+                "breaks": [0.0, 0.0007, 0.0017, 0.0032, 0.0061, 0.0128]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 43584,
                 "min": 0,
-                "max": 1181
+                "max": 1181,
+                "breaks": [0.0, 0.0162, 0.049, 0.117, 0.2279, 0.344]
               }
             ]
           },
@@ -3742,7 +3898,8 @@
               "name": "Voting age population",
               "sum": 4779467,
               "min": 67,
-              "max": 7601
+              "max": 7601,
+              "breaks": [62, 1394, 2098, 2647, 3778, 8063]
             },
             "subgroups": [
               {
@@ -3750,49 +3907,56 @@
                 "name": "White voting age population",
                 "sum": 4069517,
                 "min": 5,
-                "max": 6597
+                "max": 6597,
+                "breaks": [0.0037, 0.2337, 0.4909, 0.7077, 0.8671, 0.9887]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 220658,
                 "min": 0,
-                "max": 2033
+                "max": 2033,
+                "breaks": [0.0, 0.0576, 0.1867, 0.3875, 0.6154, 0.8713]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 271003,
                 "min": 0,
-                "max": 1735
+                "max": 1735,
+                "breaks": [0.0, 0.0581, 0.1551, 0.3105, 0.5382, 0.911]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 8150,
                 "min": 0,
-                "max": 102
+                "max": 102,
+                "breaks": [0.0, 0.0019, 0.0054, 0.0235, 0.0547, 0.2564]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 1317,
                 "min": 0,
-                "max": 14
+                "max": 14,
+                "breaks": [0.0, 0.0002, 0.0006, 0.0013, 0.0022, 0.004]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 177829,
                 "min": 0,
-                "max": 3069
+                "max": 3069,
+                "breaks": [0.0, 0.037, 0.0898, 0.1642, 0.2995, 0.5335]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 30993,
                 "min": 0,
-                "max": 1177
+                "max": 1177,
+                "breaks": [0.0, 0.0114, 0.0367, 0.0892, 0.1961, 0.3157]
               }
             ]
           },
@@ -4024,7 +4188,7 @@
               "sum": 6727041,
               "min": 76,
               "max": 10369,
-              "breaks": [76, 1582, 2602, 3318, 4513, 10369]
+              "breaks": [76, 1619, 2537, 3284, 4609, 10369]
             },
             "subgroups": [
               {
@@ -4033,7 +4197,7 @@
                 "sum": 5077097,
                 "min": 11,
                 "max": 8331,
-                "breaks": [0.0266, 0.3183, 0.5665, 0.7491, 0.8772, 0.9808]
+                "breaks": [0.0075, 0.2781, 0.5173, 0.7021, 0.8577, 0.9808]
               },
               {
                 "key": "NH_BLACK",
@@ -4041,7 +4205,7 @@
                 "sum": 445770,
                 "min": 0,
                 "max": 2906,
-                "breaks": [0.0, 0.0486, 0.1301, 0.2803, 0.5028, 0.8502]
+                "breaks": [0.0, 0.0546, 0.1459, 0.3068, 0.5439, 0.8564]
               },
               {
                 "key": "HISP",
@@ -4049,7 +4213,7 @@
                 "sum": 680464,
                 "min": 0,
                 "max": 3345,
-                "breaks": [0.0, 0.0755, 0.2013, 0.3792, 0.611, 0.9253]
+                "breaks": [0.0, 0.0696, 0.1788, 0.345, 0.5884, 0.9253]
               },
               {
                 "key": "NH_ASIAN",
@@ -4057,7 +4221,7 @@
                 "sum": 386992,
                 "min": 0,
                 "max": 4166,
-                "breaks": [0.0, 0.0353, 0.0841, 0.1594, 0.2852, 0.5458]
+                "breaks": [0.0, 0.0377, 0.0876, 0.1618, 0.2965, 0.546]
               },
               {
                 "key": "NH_AMIN",
@@ -4065,7 +4229,7 @@
                 "sum": 34492,
                 "min": 0,
                 "max": 205,
-                "breaks": [0.0, 0.0051, 0.011, 0.0346, 0.0692, 0.2986]
+                "breaks": [0.0, 0.0052, 0.0109, 0.0349, 0.0695, 0.3009]
               },
               {
                 "key": "NH_NHPI",
@@ -4073,7 +4237,7 @@
                 "sum": 6184,
                 "min": 0,
                 "max": 40,
-                "breaks": [0.0, 0.0005, 0.0015, 0.0028, 0.0054, 0.0109]
+                "breaks": [0.0, 0.0007, 0.0017, 0.0032, 0.0061, 0.0128]
               },
               {
                 "key": "NH_OTHER",
@@ -4081,7 +4245,7 @@
                 "sum": 89748,
                 "min": 0,
                 "max": 1077,
-                "breaks": [0.0, 0.0128, 0.0364, 0.0723, 0.1269, 0.2004]
+                "breaks": [0.0, 0.0162, 0.049, 0.117, 0.2279, 0.344]
               }
             ]
           },
@@ -4094,7 +4258,7 @@
               "sum": 5123060,
               "min": 62,
               "max": 8063,
-              "breaks": [62.0, 1260, 2082, 2626, 3699, 8063]
+              "breaks": [62, 1394, 2098, 2647, 3778, 8063]
             },
             "subgroups": [
               {
@@ -4103,7 +4267,7 @@
                 "sum": 4024314,
                 "min": 3,
                 "max": 6632,
-                "breaks": [0.0271, 0.3556, 0.6102, 0.7816, 0.8984, 0.9887]
+                "breaks": [0.0037, 0.2337, 0.4909, 0.7077, 0.8671, 0.9887]
               },
               {
                 "key": "BVAP",
@@ -4111,7 +4275,7 @@
                 "sum": 287367,
                 "min": 0,
                 "max": 2030,
-                "breaks": [0.0, 0.0463, 0.1406, 0.3004, 0.5821, 0.8637]
+                "breaks": [0.0, 0.0576, 0.1867, 0.3875, 0.6154, 0.8713]
               },
               {
                 "key": "HVAP",
@@ -4119,7 +4283,7 @@
                 "sum": 415465,
                 "min": 0,
                 "max": 2098,
-                "breaks": [0.0, 0.0588, 0.1685, 0.3456, 0.6097, 0.911]
+                "breaks": [0.0, 0.0581, 0.1551, 0.3105, 0.5382, 0.911]
               },
               {
                 "key": "AMINVAP",
@@ -4127,7 +4291,7 @@
                 "sum": 7229,
                 "min": 0,
                 "max": 126,
-                "breaks": [0.0, 0.0016, 0.0051, 0.0231, 0.0543, 0.253]
+                "breaks": [0.0, 0.0019, 0.0054, 0.0235, 0.0547, 0.2564]
               },
               {
                 "key": "NHPIVAP",
@@ -4135,7 +4299,7 @@
                 "sum": 810,
                 "min": 0,
                 "max": 9,
-                "breaks": [0.0, 0.0002, 0.0006, 0.0011, 0.0019, 0.0036]
+                "breaks": [0.0, 0.0002, 0.0006, 0.0013, 0.0022, 0.004]
               },
               {
                 "key": "ASIANVAP",
@@ -4143,7 +4307,7 @@
                 "sum": 267838,
                 "min": 0,
                 "max": 3594,
-                "breaks": [0.0, 0.0308, 0.0796, 0.1565, 0.291, 0.5333]
+                "breaks": [0.0, 0.037, 0.0898, 0.1642, 0.2995, 0.5335]
               },
               {
                 "key": "OTHERVAP",
@@ -4151,7 +4315,7 @@
                 "sum": 44891,
                 "min": 0,
                 "max": 562,
-                "breaks": [0.0, 0.0082, 0.025, 0.0491, 0.0888, 0.173]
+                "breaks": [0.0, 0.0114, 0.0367, 0.0892, 0.1961, 0.3157]
               },
               {
                 "key": "2MOREVAP",
@@ -4159,7 +4323,7 @@
                 "sum": 68414,
                 "min": 0,
                 "max": 311,
-                "breaks": [0.0, 0.0091, 0.0164, 0.0274, 0.0502, 0.1014]
+                "breaks": [0.0, 0.0108, 0.0202, 0.0364, 0.0621, 0.1014]
               }
             ]
           },
@@ -4407,7 +4571,8 @@
               "name": "Total population",
               "sum": 10129672,
               "min": 0,
-              "max": 11242
+              "max": 11242,
+              "breaks": [0, 1319, 2171, 3021, 4708, 11242]
             },
             "subgroups": [
               {
@@ -4415,49 +4580,56 @@
                 "name": "White population",
                 "sum": 7737567,
                 "min": 0,
-                "max": 9854
+                "max": 9854,
+                "breaks": [0.0, 0.2272, 0.5186, 0.7315, 0.877, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 1474759,
                 "min": 0,
-                "max": 3327
+                "max": 3327,
+                "breaks": [0.0, 0.0838, 0.2479, 0.5065, 0.7962, 0.9911]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 477874,
                 "min": 0,
-                "max": 4427
+                "max": 4427,
+                "breaks": [0.0, 0.0369, 0.0962, 0.2249, 0.4777, 0.7788]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 282415,
                 "min": 0,
-                "max": 2142
+                "max": 2142,
+                "breaks": [0.0, 0.0296, 0.0875, 0.1884, 0.3532, 0.6757]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 120852,
                 "min": 0,
-                "max": 1258
+                "max": 1258,
+                "breaks": [0.0, 0.0134, 0.0449, 0.113, 0.2278, 0.5276]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 6681,
                 "min": 0,
-                "max": 84
+                "max": 84,
+                "breaks": [0.0, 0.0006, 0.0017, 0.0037, 0.0097, 0.0215]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 17160,
                 "min": 0,
-                "max": 49
+                "max": 49,
+                "breaks": [0.0, 0.001, 0.0027, 0.0052, 0.0104, 0.0385]
               }
             ]
           },
@@ -4469,7 +4641,8 @@
               "name": "Voting age population",
               "sum": 7537009,
               "min": 0,
-              "max": 10165
+              "max": 10165,
+              "breaks": [0, 981, 1611, 2265, 4083, 10165]
             },
             "subgroups": [
               {
@@ -4477,56 +4650,64 @@
                 "name": "White voting age population",
                 "sum": 5958114,
                 "min": 0,
-                "max": 8928
+                "max": 8928,
+                "breaks": [0.0, 0.1893, 0.4813, 0.7248, 0.8829, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 996127,
                 "min": 0,
-                "max": 3217
+                "max": 3217,
+                "breaks": [0.0, 0.0765, 0.2417, 0.5044, 0.7927, 0.988]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 262116,
                 "min": 0,
-                "max": 2440
+                "max": 2440,
+                "breaks": [0.0, 0.0298, 0.0818, 0.2021, 0.4439, 0.7487]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 37858,
                 "min": 0,
-                "max": 681
+                "max": 681,
+                "breaks": [0.0, 0.0165, 0.0629, 0.1379, 0.2768, 0.437]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 1213,
                 "min": 0,
-                "max": 47
+                "max": 47,
+                "breaks": [0.0, 0.0003, 0.0011, 0.0026, 0.0054, 0.0119]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 173152,
                 "min": 0,
-                "max": 1536
+                "max": 1536,
+                "breaks": [0.0, 0.0252, 0.0766, 0.1651, 0.3269, 0.6485]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 4212,
                 "min": 0,
-                "max": 22
+                "max": 22,
+                "breaks": [0.0, 0.0005, 0.0015, 0.0032, 0.0062, 0.0131]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 91341,
                 "min": 0,
-                "max": 236
+                "max": 236,
+                "breaks": [0.0, 0.0075, 0.013, 0.0203, 0.0344, 0.0904]
               }
             ]
           }
@@ -4615,7 +4796,8 @@
               "name": "Total population",
               "sum": 5299241,
               "min": 0,
-              "max": 12448
+              "max": 12448,
+              "breaks": [0, 795, 1861, 2975, 4406, 12448]
             },
             "subgroups": [
               {
@@ -4623,56 +4805,64 @@
                 "name": "White population",
                 "sum": 4400672,
                 "min": 0,
-                "max": 11180
+                "max": 11180,
+                "breaks": [0.0, 0.3699, 0.6296, 0.8052, 0.9201, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 267943,
                 "min": 0,
-                "max": 3351
+                "max": 3351,
+                "breaks": [0.0, 0.0286, 0.0922, 0.1916, 0.3582, 0.6592]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 248532,
                 "min": 0,
-                "max": 2195
+                "max": 2195,
+                "breaks": [0.0, 0.0268, 0.0778, 0.1724, 0.3153, 0.513]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 211608,
                 "min": 0,
-                "max": 2696
+                "max": 2696,
+                "breaks": [0.0, 0.0202, 0.0616, 0.1299, 0.2392, 0.4618]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 54129,
                 "min": 0,
-                "max": 2364
+                "max": 2364,
+                "breaks": [0.0, 0.0337, 0.1542, 0.4071, 0.7381, 0.9773]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 1541,
                 "min": 0,
-                "max": 50
+                "max": 50,
+                "breaks": [0.0, 0.0007, 0.0032, 0.0093, 0.0301, 0.1716]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 101484,
                 "min": 0,
-                "max": 329
+                "max": 329,
+                "breaks": [0.0, 0.0127, 0.032, 0.085, 0.1905, 0.8277]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 5370,
                 "min": 0,
-                "max": 33
+                "max": 33,
+                "breaks": [0.0, 0.001, 0.0037, 0.0108, 0.0253, 0.0922]
               }
             ]
           },
@@ -4684,7 +4874,8 @@
               "name": "Voting age population",
               "sum": 4015900,
               "min": 0,
-              "max": 8630
+              "max": 8630,
+              "breaks": [0, 543, 1313, 2179, 3239, 8630]
             },
             "subgroups": [
               {
@@ -4692,56 +4883,64 @@
                 "name": "White voting age population",
                 "sum": 3458806,
                 "min": 0,
-                "max": 7937
+                "max": 7937,
+                "breaks": [0.0, 0.3826, 0.649, 0.8235, 0.9319, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 173599,
                 "min": 0,
-                "max": 2261
+                "max": 2261,
+                "breaks": [0.0, 0.0244, 0.0807, 0.176, 0.342, 0.6307]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 147220,
                 "min": 0,
-                "max": 1299
+                "max": 1299,
+                "breaks": [0.0, 0.0216, 0.0641, 0.1386, 0.2582, 0.4602]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 36760,
                 "min": 0,
-                "max": 1448
+                "max": 1448,
+                "breaks": [0.0, 0.0419, 0.1731, 0.3994, 0.6955, 0.9791]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 1053,
                 "min": 0,
-                "max": 29
+                "max": 29,
+                "breaks": [0.0, 0.0007, 0.003, 0.0079, 0.0177, 0.1265]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 144702,
                 "min": 0,
-                "max": 1568
+                "max": 1568,
+                "breaks": [0.0, 0.0167, 0.0497, 0.103, 0.1942, 0.4128]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 2774,
                 "min": 0,
-                "max": 18
+                "max": 18,
+                "breaks": [0.0, 0.0008, 0.0025, 0.0057, 0.0142, 0.0368]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 43582,
                 "min": 0,
-                "max": 135
+                "max": 135,
+                "breaks": [0.0, 0.0079, 0.0223, 0.0653, 0.1902, 0.7425]
               }
             ]
           },
@@ -5176,7 +5375,8 @@
               "name": "Total Population",
               "sum": 2967297,
               "min": 0,
-              "max": 7131
+              "max": 7131,
+              "breaks": [0, 980, 1482, 2108, 3169, 7131]
             },
             "subgroups": [
               {
@@ -5184,42 +5384,48 @@
                 "name": "White population",
                 "sum": 1722287,
                 "min": 0,
-                "max": 5546
+                "max": 5546,
+                "breaks": [0.0, 0.1866, 0.4017, 0.6091, 0.8024, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 1093512,
                 "min": 0,
-                "max": 3753
+                "max": 3753,
+                "breaks": [0.0, 0.1696, 0.3721, 0.5849, 0.7964, 1.0]
               },
               {
                 "key": "HPOP",
                 "name": "Hispanic population",
                 "sum": 81481,
                 "min": 0,
-                "max": 1839
+                "max": 1839,
+                "breaks": [0.0, 0.0237, 0.065, 0.1537, 0.2989, 0.5235]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 25477,
                 "min": 0,
-                "max": 432
+                "max": 432,
+                "breaks": [0.0, 0.009, 0.0294, 0.0678, 0.147, 0.303]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 13845,
                 "min": 0,
-                "max": 1756
+                "max": 1756,
+                "breaks": [0.0, 0.0417, 0.2457, 0.4822, 0.675, 0.8549]
               },
               {
                 "key": "NH_NAHI",
                 "name": "Hawaiian Native population",
                 "sum": 948,
                 "min": 0,
-                "max": 29
+                "max": 29,
+                "breaks": [0.0, 0.0006, 0.0024, 0.0078, 0.0148, 0.0253]
               }
             ]
           },
@@ -5231,7 +5437,8 @@
               "name": "Voting age population",
               "sum": 2211742,
               "min": 0,
-              "max": 5086
+              "max": 5086,
+              "breaks": [0, 752, 1168, 1724, 2643, 5086]
             },
             "subgroups": [
               {
@@ -5239,42 +5446,48 @@
                 "name": "White voting age population",
                 "sum": 1370641,
                 "min": 0,
-                "max": 4092
+                "max": 4092,
+                "breaks": [0.0, 0.1908, 0.4064, 0.6108, 0.808, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 767499,
                 "min": 0,
-                "max": 3119
+                "max": 3119,
+                "breaks": [0.0, 0.1609, 0.3544, 0.5685, 0.792, 1.0]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 54977,
                 "min": 0,
-                "max": 1829
+                "max": 1829,
+                "breaks": [0.0, 0.0252, 0.0757, 0.1753, 0.3379, 0.5806]
               },
               {
                 "key": "NAHIVAP",
                 "name": "Native Hawaiian voting age population",
                 "sum": 912,
                 "min": 0,
-                "max": 18
+                "max": 18,
+                "breaks": [0.0, 0.0008, 0.0028, 0.008, 0.0196, 0.0523]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 19643,
                 "min": 0,
-                "max": 293
+                "max": 293,
+                "breaks": [0.0, 0.0091, 0.0288, 0.0667, 0.168, 0.3276]
               },
               {
                 "key": "AMINVAP",
                 "name": "American Indian voting age population",
                 "sum": 10216,
                 "min": 0,
-                "max": 1125
+                "max": 1125,
+                "breaks": [0.0, 0.0425, 0.2153, 0.462, 0.6576, 0.8377]
               }
             ]
           }
@@ -5339,7 +5552,8 @@
               "name": "2010 Census Population",
               "sum": 5843434,
               "min": 0,
-              "max": 24794
+              "max": 24794,
+              "breaks": [0, 865, 1996, 3806, 9435, 24794]
             },
             "subgroups": [
               {
@@ -5347,7 +5561,8 @@
                 "name": "2010 Voting age population",
                 "sum": 4451970,
                 "min": 0,
-                "max": 19790
+                "max": 19790,
+                "breaks": [0.0, 0.0, 0.7095, 0.7813, 0.8733, 1.0]
               }
             ]
           },
@@ -5573,7 +5788,8 @@
               "name": "Total population",
               "sum": 2059179,
               "min": 0,
-              "max": 8135
+              "max": 8135,
+              "breaks": [0, 868, 1584, 2512, 4009, 8135]
             },
             "subgroups": [
               {
@@ -5581,56 +5797,64 @@
                 "name": "White population",
                 "sum": 833810,
                 "min": 0,
-                "max": 3165
+                "max": 3165,
+                "breaks": [0.0, 0.1707, 0.3461, 0.5171, 0.6865, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 35462,
                 "min": 0,
-                "max": 460
+                "max": 460,
+                "breaks": [0.0, 0.0095, 0.0233, 0.044, 0.0872, 0.1533]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 953403,
                 "min": 0,
-                "max": 8026
+                "max": 8026,
+                "breaks": [0.0, 0.2053, 0.3759, 0.5494, 0.732, 1.0]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 26305,
                 "min": 0,
-                "max": 371
+                "max": 371,
+                "breaks": [0.0, 0.0081, 0.0223, 0.0458, 0.0892, 0.1762]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 175368,
                 "min": 0,
-                "max": 3205
+                "max": 3205,
+                "breaks": [0.0, 0.0616, 0.2074, 0.4588, 0.7653, 0.9966]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 1246,
                 "min": 0,
-                "max": 36
+                "max": 36,
+                "breaks": [0.0, 0.0005, 0.0015, 0.0031, 0.0067, 0.0162]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 29835,
                 "min": 0,
-                "max": 220
+                "max": 220,
+                "breaks": [0.0, 0.0076, 0.0147, 0.0228, 0.0352, 0.0787]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 3750,
                 "min": 0,
-                "max": 66
+                "max": 66,
+                "breaks": [0.0, 0.0018, 0.0056, 0.0143, 0.0311, 0.0741]
               }
             ]
           },
@@ -5642,7 +5866,8 @@
               "name": "Voting age population",
               "sum": 1540507,
               "min": 0,
-              "max": 5265
+              "max": 5265,
+              "breaks": [0, 657, 1163, 1781, 2710, 5265]
             },
             "subgroups": [
               {
@@ -5650,56 +5875,64 @@
                 "name": "White voting age population",
                 "sum": 697848,
                 "min": 0,
-                "max": 2517
+                "max": 2517,
+                "breaks": [0.0, 0.1944, 0.3822, 0.5556, 0.7172, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 27453,
                 "min": 0,
-                "max": 314
+                "max": 314,
+                "breaks": [0.0, 0.0095, 0.0228, 0.0418, 0.0811, 0.1681]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 651326,
                 "min": 0,
-                "max": 5196
+                "max": 5196,
+                "breaks": [0.0, 0.1891, 0.3516, 0.5233, 0.7113, 1.0]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 121962,
                 "min": 0,
-                "max": 2125
+                "max": 2125,
+                "breaks": [0.0, 0.0613, 0.2119, 0.4464, 0.7291, 0.9957]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 987,
                 "min": 0,
-                "max": 23
+                "max": 23,
+                "breaks": [0.0, 0.0005, 0.0016, 0.0033, 0.0069, 0.0145]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 20956,
                 "min": 0,
-                "max": 250
+                "max": 250,
+                "breaks": [0.0, 0.009, 0.0238, 0.048, 0.0855, 0.2]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 2633,
                 "min": 0,
-                "max": 47
+                "max": 47,
+                "breaks": [0.0, 0.0016, 0.005, 0.0117, 0.0305, 0.087]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 17342,
                 "min": 0,
-                "max": 83
+                "max": 83,
+                "breaks": [0.0, 0.0055, 0.0106, 0.0163, 0.0242, 0.0502]
               }
             ]
           },
@@ -6096,7 +6329,8 @@
               "name": "Total population",
               "sum": 9535483,
               "min": 37,
-              "max": 34282
+              "max": 34282,
+              "breaks": [37, 2431, 4352, 7238, 14643, 34282]
             },
             "subgroups": [
               {
@@ -6104,56 +6338,64 @@
                 "name": "White population",
                 "sum": 6223995,
                 "min": 5,
-                "max": 22466
+                "max": 22466,
+                "breaks": [0.005, 0.2637, 0.4993, 0.6803, 0.8362, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 2019854,
                 "min": 0,
-                "max": 14255
+                "max": 14255,
+                "breaks": [0.0, 0.1053, 0.256, 0.4347, 0.6596, 0.9756]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 800120,
                 "min": 0,
-                "max": 5362
+                "max": 5362,
+                "breaks": [0.0, 0.0476, 0.0974, 0.1668, 0.2795, 0.57]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 206579,
                 "min": 0,
-                "max": 5161
+                "max": 5161,
+                "breaks": [0.0, 0.0136, 0.037, 0.0791, 0.1552, 0.3525]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 108829,
                 "min": 0,
-                "max": 5535
+                "max": 5535,
+                "breaks": [0.0, 0.0538, 0.181, 0.3075, 0.62, 0.9266]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 5259,
                 "min": 0,
-                "max": 194
+                "max": 194,
+                "breaks": [0.0, 0.0005, 0.0019, 0.0054, 0.0133, 0.0243]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 155759,
                 "min": 0,
-                "max": 1508
+                "max": 1508,
+                "breaks": [0.0, 0.0094, 0.0148, 0.021, 0.0304, 0.0677]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 15088,
                 "min": 0,
-                "max": 113
+                "max": 113,
+                "breaks": [0.0, 0.0009, 0.0022, 0.0041, 0.0103, 0.0232]
               }
             ]
           },
@@ -6165,7 +6407,8 @@
               "name": "Voting age population",
               "sum": 7253848,
               "min": 29,
-              "max": 26979
+              "max": 26979,
+              "breaks": [29, 2023, 3737, 6855, 14830, 26979]
             },
             "subgroups": [
               {
@@ -6173,56 +6416,64 @@
                 "name": "White voting age population",
                 "sum": 4964325,
                 "min": 4,
-                "max": 18646
+                "max": 18646,
+                "breaks": [0.0052, 0.2679, 0.5018, 0.6855, 0.8438, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 1480769,
                 "min": 0,
-                "max": 10419
+                "max": 10419,
+                "breaks": [0.0, 0.0966, 0.2374, 0.4107, 0.6459, 0.9812]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 492330,
                 "min": 0,
-                "max": 3624
+                "max": 3624,
+                "breaks": [0.0, 0.0402, 0.0848, 0.1484, 0.2485, 0.541]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 79295,
                 "min": 0,
-                "max": 3978
+                "max": 3978,
+                "breaks": [0.0, 0.053, 0.1703, 0.2974, 0.6176, 0.928]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 3791,
                 "min": 0,
-                "max": 133
+                "max": 133,
+                "breaks": [0.0, 0.0003, 0.0012, 0.0027, 0.0074, 0.0163]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 152537,
                 "min": 0,
-                "max": 3480
+                "max": 3480,
+                "breaks": [0.0, 0.0141, 0.0381, 0.0796, 0.1572, 0.3395]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 7167,
                 "min": 0,
-                "max": 89
+                "max": 89,
+                "breaks": [0.0, 0.0007, 0.0021, 0.0048, 0.0092, 0.0241]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 73634,
                 "min": 0,
-                "max": 671
+                "max": 671,
+                "breaks": [0.0, 0.0056, 0.0093, 0.0137, 0.0201, 0.0576]
               }
             ]
           }
@@ -6305,7 +6556,8 @@
               "name": "Total population",
               "sum": 12702379,
               "min": 0,
-              "max": 8650
+              "max": 8650,
+              "breaks": [0, 949, 1641, 2580, 4143, 8650]
             },
             "subgroups": [
               {
@@ -6313,56 +6565,64 @@
                 "name": "White population",
                 "sum": 10094652,
                 "min": 0,
-                "max": 7437
+                "max": 7437,
+                "breaks": [0.0, 0.1868, 0.4605, 0.7145, 0.8903, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 1327091,
                 "min": 0,
-                "max": 3222
+                "max": 3222,
+                "breaks": [0.0, 0.0747, 0.2349, 0.4729, 0.7546, 1.0]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 719660,
                 "min": 0,
-                "max": 2719
+                "max": 2719,
+                "breaks": [0.0, 0.048, 0.1494, 0.3417, 0.5863, 0.9387]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 346288,
                 "min": 0,
-                "max": 1757
+                "max": 1757,
+                "breaks": [0.0, 0.0262, 0.0805, 0.1773, 0.3361, 0.6888]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 16909,
                 "min": 0,
-                "max": 41
+                "max": 41,
+                "breaks": [0.0, 0.001, 0.003, 0.0066, 0.0147, 0.0392]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 2715,
                 "min": 0,
-                "max": 19
+                "max": 19,
+                "breaks": [0.0, 0.0004, 0.0015, 0.0032, 0.0065, 0.0146]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 178595,
                 "min": 0,
-                "max": 247
+                "max": 247,
+                "breaks": [0.0, 0.0091, 0.0181, 0.0301, 0.0488, 0.25]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 16469,
                 "min": 0,
-                "max": 190
+                "max": 190,
+                "breaks": [0.0, 0.0012, 0.0039, 0.009, 0.0196, 0.0402]
               }
             ]
           },
@@ -6374,7 +6634,8 @@
               "name": "Voting age population",
               "sum": 9910224,
               "min": 0,
-              "max": 7363
+              "max": 7363,
+              "breaks": [0, 714, 1227, 1930, 3111, 7363]
             },
             "subgroups": [
               {
@@ -6382,56 +6643,64 @@
                 "name": "White voting age population",
                 "sum": 8111276,
                 "min": 0,
-                "max": 5610
+                "max": 5610,
+                "breaks": [0.0, 0.1907, 0.4753, 0.7317, 0.9009, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 963866,
                 "min": 0,
-                "max": 3126
+                "max": 3126,
+                "breaks": [0.0, 0.0807, 0.2507, 0.4969, 0.772, 1.0]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 459421,
                 "min": 0,
-                "max": 1606
+                "max": 1606,
+                "breaks": [0.0, 0.0451, 0.144, 0.3306, 0.5834, 0.9382]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 13163,
                 "min": 0,
-                "max": 41
+                "max": 41,
+                "breaks": [0.0, 0.0009, 0.0027, 0.0054, 0.0111, 0.0465]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 2109,
                 "min": 0,
-                "max": 18
+                "max": 18,
+                "breaks": [0.0, 0.0004, 0.0014, 0.003, 0.0064, 0.0166]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 264676,
                 "min": 0,
-                "max": 1484
+                "max": 1484,
+                "breaks": [0.0, 0.024, 0.0739, 0.1636, 0.3052, 0.6693]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 9383,
                 "min": 0,
-                "max": 180
+                "max": 180,
+                "breaks": [0.0, 0.001, 0.0033, 0.0079, 0.0193, 0.0464]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 86330,
                 "min": 0,
-                "max": 127
+                "max": 127,
+                "breaks": [0.0, 0.0053, 0.0111, 0.0189, 0.03, 0.069]
               }
             ]
           },
@@ -6668,7 +6937,8 @@
               "name": "Total Population",
               "sum": 1526006,
               "min": 0,
-              "max": 4535
+              "max": 4535,
+              "breaks": [0, 67, 205, 503, 1288, 4535]
             },
             "subgroups": [
               {
@@ -6676,42 +6946,48 @@
                 "name": "White population",
                 "sum": 562585,
                 "min": 0,
-                "max": 1290
+                "max": 1290,
+                "breaks": [0.0, 0.1026, 0.3273, 0.5945, 0.8261, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 644287,
                 "min": 0,
-                "max": 3169
+                "max": 3169,
+                "breaks": [0.0, 0.1026, 0.3263, 0.5969, 0.8378, 1.0]
               },
               {
                 "key": "HPOP",
                 "name": "Hispanic population",
                 "sum": 187611,
                 "min": 0,
-                "max": 719
+                "max": 719,
+                "breaks": [0.0, 0.0439, 0.1558, 0.3619, 0.6667, 1.0]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 95521,
                 "min": 0,
-                "max": 488
+                "max": 488,
+                "breaks": [0.0, 0.0418, 0.1471, 0.3067, 0.6, 1.0]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 3498,
                 "min": 0,
-                "max": 11
+                "max": 11,
+                "breaks": [0.0, 0.0064, 0.0256, 0.0612, 0.1356, 0.25]
               },
               {
                 "key": "NH_NAHI",
                 "name": "Hawaiian Native population",
                 "sum": 457,
                 "min": 0,
-                "max": 9
+                "max": 9,
+                "breaks": [0.0, 0.0095, 0.0392, 0.087, 0.1429, 0.25]
               }
             ]
           }
@@ -6776,7 +7052,8 @@
               "name": "Total Population",
               "sum": 116501,
               "min": 0,
-              "max": 2055
+              "max": 2055,
+              "breaks": [0, 62, 239, 622, 1387, 2055]
             },
             "subgroups": [
               {
@@ -6784,42 +7061,48 @@
                 "name": "White population",
                 "sum": 42045,
                 "min": 0,
-                "max": 663
+                "max": 663,
+                "breaks": [0.0, 0.1184, 0.3238, 0.507, 0.7021, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 2929,
                 "min": 0,
-                "max": 83
+                "max": 83,
+                "breaks": [0.0, 0.0159, 0.0531, 0.1176, 0.2391, 1.0]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 43544,
                 "min": 0,
-                "max": 1594
+                "max": 1594,
+                "breaks": [0.0, 0.0857, 0.2462, 0.4175, 0.6541, 1.0]
               },
               {
                 "key": "HPOP",
                 "name": "Hispanic population",
                 "sum": 22590,
                 "min": 0,
-                "max": 595
+                "max": 595,
+                "breaks": [0.0, 0.0588, 0.1727, 0.3129, 0.5556, 1.0]
               },
               {
                 "key": "NH_NAHI",
                 "name": "Hawaiian Native population",
                 "sum": 604,
                 "min": 0,
-                "max": 33
+                "max": 33,
+                "breaks": [0.0, 0.0096, 0.0361, 0.1062, 0.2276, 0.5]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 240,
                 "min": 0,
-                "max": 10
+                "max": 10,
+                "breaks": [0.0, 0.005, 0.0172, 0.0435, 0.069, 0.5]
               }
             ]
           }
@@ -6890,7 +7173,8 @@
               "name": "Total population",
               "sum": 25145561,
               "min": 0,
-              "max": 22091
+              "max": 22091,
+              "breaks": [0, 1454, 3282, 5355, 8265, 22091]
             },
             "subgroups": [
               {
@@ -6898,28 +7182,32 @@
                 "name": "White population",
                 "sum": 11397345,
                 "min": 0,
-                "max": 8787
+                "max": 8787,
+                "breaks": [0.0, 0.1569, 0.366, 0.5732, 0.7654, 1.0]
               },
               {
                 "key": "BLACK",
                 "name": "Black population",
                 "sum": 3168469,
                 "min": 0,
-                "max": 7630
+                "max": 7630,
+                "breaks": [0.0, 0.0687, 0.1882, 0.3684, 0.6374, 1.0]
               },
               {
                 "key": "HISPANIC",
                 "name": "Hispanic population",
                 "sum": 9460921,
                 "min": 0,
-                "max": 17265
+                "max": 17265,
+                "breaks": [0.0, 0.1563, 0.3297, 0.5405, 0.779, 1.0]
               },
               {
                 "key": "OTHER",
                 "name": "Other races",
                 "sum": 1267977,
                 "min": 0,
-                "max": 5095
+                "max": 5095,
+                "breaks": [0.0, 0.0396, 0.1127, 0.2537, 0.5717, 1.0]
               }
             ]
           },
@@ -6931,7 +7219,8 @@
               "name": "Voting age population",
               "sum": 18279737,
               "min": 0,
-              "max": 15368
+              "max": 15368,
+              "breaks": [0, 1067, 2391, 3863, 6009, 15368]
             },
             "subgroups": [
               {
@@ -6939,28 +7228,32 @@
                 "name": "White voting age population",
                 "sum": 9074684,
                 "min": 0,
-                "max": 8234
+                "max": 8234,
+                "breaks": [0.0, 0.1672, 0.3853, 0.595, 0.7833, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 2196259,
                 "min": 0,
-                "max": 4847
+                "max": 4847,
+                "breaks": [0.0, 0.0647, 0.1825, 0.3673, 0.6379, 1.0]
               },
               {
                 "key": "HISPVAP",
                 "name": "Hispanic voting age population",
                 "sum": 6143144,
                 "min": 0,
-                "max": 11566
+                "max": 11566,
+                "breaks": [0.0, 0.1402, 0.3048, 0.5154, 0.7645, 1.0]
               },
               {
                 "key": "OTHVAP",
                 "name": "Other races voting age population",
                 "sum": 933861,
                 "min": 0,
-                "max": 3464
+                "max": 3464,
+                "breaks": [0.0, 0.0383, 0.1081, 0.2466, 0.5655, 1.0]
               }
             ]
           },
@@ -7140,7 +7433,8 @@
               "name": "Total population",
               "sum": 625640,
               "min": 62,
-              "max": 42417
+              "max": 42417,
+              "breaks": [62, 2216, 5282, 12046, 19587, 42417]
             },
             "subgroups": [
               {
@@ -7148,63 +7442,72 @@
                 "name": "White population",
                 "sum": 596195,
                 "min": 59,
-                "max": 37727
+                "max": 37727,
+                "breaks": [0.8265, 0.8894, 0.9372, 0.9601, 0.9741, 0.9923]
               },
               {
                 "key": "BLACK",
                 "name": "Black population",
                 "sum": 6277,
                 "min": 0,
-                "max": 1653
+                "max": 1653,
+                "breaks": [0.0, 0.0038, 0.009, 0.0194, 0.039, 0.0685]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 9205,
                 "min": 0,
-                "max": 1144
+                "max": 1144,
+                "breaks": [0.0, 0.007, 0.0125, 0.0191, 0.032, 0.0577]
               },
               {
                 "key": "ASIAN",
                 "name": "Asian population",
                 "sum": 7947,
                 "min": 0,
-                "max": 1510
+                "max": 1510,
+                "breaks": [0.0, 0.0036, 0.0075, 0.0145, 0.0356, 0.0615]
               },
               {
                 "key": "AMIN",
                 "name": "Native American and Alaskan Native population",
                 "sum": 2207,
                 "min": 0,
-                "max": 158
+                "max": 158,
+                "breaks": [0.0, 0.0022, 0.0048, 0.0082, 0.017, 0.0274]
               },
               {
                 "key": "NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 160,
                 "min": 0,
-                "max": 21
+                "max": 21,
+                "breaks": [0.0, 0.0002, 0.0006, 0.0015, 0.0028, 0.0046]
               },
               {
                 "key": "2MORE",
                 "name": "Two or more races",
                 "sum": 10749,
                 "min": 0,
-                "max": 1102
+                "max": 1102,
+                "breaks": [0.0, 0.009, 0.0158, 0.0241, 0.0341, 0.0521]
               },
               {
                 "key": "OTHER",
                 "name": "Other races",
                 "sum": 2105,
                 "min": 0,
-                "max": 273
+                "max": 273,
+                "breaks": [0.0, 0.0018, 0.0047, 0.0095, 0.0148, 0.0481]
               },
               {
                 "key": "VAP",
                 "name": "Voting age population",
                 "sum": 496422,
                 "min": 51,
-                "max": 36688
+                "max": 36688,
+                "breaks": [0.7255, 0.7646, 0.7878, 0.8089, 0.8401, 0.8876]
               }
             ]
           },
@@ -7417,7 +7720,8 @@
               "name": "Population",
               "sum": 5686986,
               "min": 0,
-              "max": 3905
+              "max": 3905,
+              "breaks": [0, 414, 781, 1338, 2205, 3905]
             },
             "subgroups": [
               {
@@ -7425,56 +7729,64 @@
                 "name": "White population",
                 "sum": 4738411,
                 "min": 0,
-                "max": 3245
+                "max": 3245,
+                "breaks": [0.0, 0.256, 0.57, 0.7886, 0.9148, 1.0]
               },
               {
                 "key": "BLACK",
                 "name": "Black/African American population",
                 "sum": 380660,
                 "min": 0,
-                "max": 2770
+                "max": 2770,
+                "breaks": [0.0, 0.0586, 0.2181, 0.4905, 0.775, 0.968]
               },
               {
                 "key": "HISPANIC",
                 "name": "Population of Hispanic origin",
                 "sum": 336056,
                 "min": 0,
-                "max": 2495
+                "max": 2495,
+                "breaks": [0.0, 0.0371, 0.1079, 0.2459, 0.5192, 1.0]
               },
               {
                 "key": "ASIAN",
                 "name": "Asian population",
                 "sum": 143931,
                 "min": 0,
-                "max": 1475
+                "max": 1475,
+                "breaks": [0.0, 0.0212, 0.0627, 0.1377, 0.345, 1.0]
               },
               {
                 "key": "AMINDIAN",
                 "name": "American Indian or Alaska Native population",
                 "sum": 68593,
                 "min": 0,
-                "max": 771
+                "max": 771,
+                "breaks": [0.0, 0.0231, 0.1028, 0.3, 0.6385, 0.9391]
               },
               {
                 "key": "PISLAND",
                 "name": "Native Hawaiian or other Pacific Islander population",
                 "sum": 2639,
                 "min": 0,
-                "max": 23
+                "max": 23,
+                "breaks": [0.0, 0.0008, 0.0029, 0.0069, 0.0189, 0.0447]
               },
               {
                 "key": "OTHER",
                 "name": "Population of other race",
                 "sum": 5249,
                 "min": 0,
-                "max": 27
+                "max": 27,
+                "breaks": [0.0, 0.0011, 0.004, 0.0122, 0.0323, 1.0]
               },
               {
                 "key": "OTHERMLT",
                 "name": "Population of other multiple races",
                 "sum": 11447,
                 "min": 0,
-                "max": 51
+                "max": 51,
+                "breaks": [0.0, 0.0017, 0.0053, 0.0114, 0.0328, 0.086]
               }
             ]
           },
@@ -7696,7 +8008,8 @@
               "name": "Total population",
               "sum": 7999808,
               "min": 57,
-              "max": 23501
+              "max": 23501,
+              "breaks": [57, 2181, 3821, 5743, 9970, 23501]
             },
             "subgroups": [
               {
@@ -7704,56 +8017,64 @@
                 "name": "White population",
                 "sum": 5185250,
                 "min": 16,
-                "max": 13957
+                "max": 13957,
+                "breaks": [0.0093, 0.2815, 0.5205, 0.7038, 0.8554, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 1522564,
                 "min": 0,
-                "max": 5617
+                "max": 5617,
+                "breaks": [0.0, 0.0959, 0.2283, 0.4138, 0.6733, 0.9644]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 630652,
                 "min": 0,
-                "max": 5054
+                "max": 5054,
+                "breaks": [0.0, 0.043, 0.1021, 0.1956, 0.3387, 0.8431]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 435196,
                 "min": 0,
-                "max": 4605
+                "max": 4605,
+                "breaks": [0.0, 0.0305, 0.0879, 0.1727, 0.2952, 0.5776]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 19565,
                 "min": 0,
-                "max": 369
+                "max": 369,
+                "breaks": [0.0, 0.0023, 0.0054, 0.0151, 0.0478, 0.1569]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 4493,
                 "min": 0,
-                "max": 63
+                "max": 63,
+                "breaks": [0.0, 0.0005, 0.0015, 0.0032, 0.0069, 0.0146]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 180470,
                 "min": 0,
-                "max": 657
+                "max": 657,
+                "breaks": [0.0, 0.0099, 0.0176, 0.0259, 0.036, 0.1139]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 14406,
                 "min": 0,
-                "max": 99
+                "max": 99,
+                "breaks": [0.0, 0.0011, 0.0026, 0.0049, 0.0128, 0.0341]
               }
             ]
           },
@@ -7765,7 +8086,8 @@
               "name": "Voting age population",
               "sum": 6146142,
               "min": 44,
-              "max": 22925
+              "max": 22925,
+              "breaks": [44, 1703, 2963, 4468, 9247, 22925]
             },
             "subgroups": [
               {
@@ -7773,56 +8095,64 @@
                 "name": "White voting age population",
                 "sum": 4132189,
                 "min": 16,
-                "max": 13463
+                "max": 13463,
+                "breaks": [0.0125, 0.2866, 0.5323, 0.7142, 0.8638, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 1133875,
                 "min": 0,
-                "max": 5098
+                "max": 5098,
+                "breaks": [0.0, 0.0968, 0.228, 0.4126, 0.6712, 0.9645]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 425694,
                 "min": 0,
-                "max": 3827
+                "max": 3827,
+                "breaks": [0.0, 0.0397, 0.096, 0.183, 0.3188, 0.8456]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 15064,
                 "min": 0,
-                "max": 304
+                "max": 304,
+                "breaks": [0.0, 0.0025, 0.0065, 0.0218, 0.0506, 0.1584]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 3404,
                 "min": 0,
-                "max": 63
+                "max": 63,
+                "breaks": [0.0, 0.0003, 0.001, 0.002, 0.0038, 0.0116]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 333048,
                 "min": 0,
-                "max": 3315
+                "max": 3315,
+                "breaks": [0.0, 0.031, 0.0893, 0.1729, 0.3016, 0.6023]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 7034,
                 "min": 0,
-                "max": 98
+                "max": 98,
+                "breaks": [0.0, 0.0007, 0.0018, 0.0036, 0.0099, 0.0399]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 88794,
                 "min": 0,
-                "max": 628
+                "max": 628,
+                "breaks": [0.0, 0.0081, 0.0148, 0.023, 0.0453, 0.0984]
               }
             ]
           },
@@ -8085,7 +8415,8 @@
               "name": "Total population",
               "sum": 1051746,
               "min": 3,
-              "max": 7597
+              "max": 7597,
+              "breaks": [3, 1245, 2256, 3178, 4314, 7597]
             },
             "subgroups": [
               {
@@ -8093,49 +8424,56 @@
                 "name": "White population",
                 "sum": 802951,
                 "min": 0,
-                "max": 6348
+                "max": 6348,
+                "breaks": [0.0255, 0.3315, 0.6007, 0.7792, 0.8978, 0.9808]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 51325,
                 "min": 0,
-                "max": 1128
+                "max": 1128,
+                "breaks": [0.0, 0.0357, 0.0882, 0.1643, 0.2465, 0.377]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 130420,
                 "min": 0,
-                "max": 3574
+                "max": 3574,
+                "breaks": [0.0028, 0.0916, 0.2283, 0.4098, 0.5906, 0.7518]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 29768,
                 "min": 0,
-                "max": 848
+                "max": 848,
+                "breaks": [0.0, 0.0294, 0.0851, 0.168, 0.2628, 0.8943]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 3828,
                 "min": 0,
-                "max": 112
+                "max": 112,
+                "breaks": [0.0, 0.0023, 0.0053, 0.01, 0.0189, 0.0387]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 252,
                 "min": 0,
-                "max": 18
+                "max": 18,
+                "breaks": [0.0, 0.0002, 0.0008, 0.0018, 0.0036, 0.0071]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 8703,
                 "min": 0,
-                "max": 509
+                "max": 509,
+                "breaks": [0.0, 0.0065, 0.0197, 0.0441, 0.0849, 0.1591]
               }
             ]
           },
@@ -8147,7 +8485,8 @@
               "name": "Voting age population",
               "sum": 827884,
               "min": 3,
-              "max": 7118
+              "max": 7118,
+              "breaks": [3, 1131, 1973, 2794, 3882, 7118]
             },
             "subgroups": [
               {
@@ -8155,56 +8494,64 @@
                 "name": "White voting age population",
                 "sum": 660166,
                 "min": 0,
-                "max": 5943
+                "max": 5943,
+                "breaks": [0.0249, 0.2031, 0.4061, 0.6627, 0.8578, 0.9856]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 36984,
                 "min": 0,
-                "max": 813
+                "max": 813,
+                "breaks": [0.0, 0.0253, 0.0608, 0.1119, 0.1943, 0.377]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 84488,
                 "min": 0,
-                "max": 2488
+                "max": 2488,
+                "breaks": [0.0028, 0.0718, 0.1843, 0.3723, 0.5555, 0.7123]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 2737,
                 "min": 0,
-                "max": 85
+                "max": 85,
+                "breaks": [0.0, 0.002, 0.0048, 0.0093, 0.0164, 0.0384]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 190,
                 "min": 0,
-                "max": 12
+                "max": 12,
+                "breaks": [0.0, 0.0003, 0.001, 0.002, 0.0035, 0.0065]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 23029,
                 "min": 0,
-                "max": 628
+                "max": 628,
+                "breaks": [0.0, 0.0307, 0.087, 0.1709, 0.2719, 0.8954]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 6233,
                 "min": 0,
-                "max": 373
+                "max": 373,
+                "breaks": [0.0, 0.0058, 0.0184, 0.0429, 0.0807, 0.1641]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 12793,
                 "min": 0,
-                "max": 263
+                "max": 263,
+                "breaks": [0.0, 0.0104, 0.02, 0.0326, 0.0484, 0.0867]
               }
             ]
           }
@@ -8297,7 +8644,8 @@
               "name": "Total population",
               "sum": 2762995,
               "min": 0,
-              "max": 6083
+              "max": 6083,
+              "breaks": [0, 733, 1443, 2243, 3809, 6083]
             },
             "subgroups": [
               {
@@ -8305,56 +8653,64 @@
                 "name": "White population",
                 "sum": 2220808,
                 "min": 0,
-                "max": 5250
+                "max": 5250,
+                "breaks": [0.0, 0.4133, 0.643, 0.7802, 0.8815, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 25112,
                 "min": 0,
-                "max": 275
+                "max": 275,
+                "breaks": [0.0, 0.0062, 0.0164, 0.0342, 0.0696, 0.1397]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 357322,
                 "min": 0,
-                "max": 2569
+                "max": 2569,
+                "breaks": [0.0, 0.0689, 0.1433, 0.2517, 0.4091, 0.7698]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 53246,
                 "min": 0,
-                "max": 1054
+                "max": 1054,
+                "breaks": [0.0, 0.014, 0.0346, 0.0745, 0.1547, 0.2659]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 26233,
                 "min": 0,
-                "max": 1201
+                "max": 1201,
+                "breaks": [0.0, 0.0436, 0.1786, 0.4135, 0.6544, 0.9717]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 23162,
                 "min": 0,
-                "max": 454
+                "max": 454,
+                "breaks": [0.0, 0.0059, 0.018, 0.0383, 0.0752, 0.1339]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 47998,
                 "min": 0,
-                "max": 153
+                "max": 153,
+                "breaks": [0.0, 0.0099, 0.0186, 0.029, 0.0743, 0.1696]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 3177,
                 "min": 0,
-                "max": 88
+                "max": 88,
+                "breaks": [0.0, 0.0014, 0.0048, 0.019, 0.0444, 0.0785]
               }
             ]
           },
@@ -8366,7 +8722,8 @@
               "name": "Voting age population",
               "sum": 1891928,
               "min": 0,
-              "max": 5797
+              "max": 5797,
+              "breaks": [0, 498, 989, 1561, 3241, 5797]
             },
             "subgroups": [
               {
@@ -8374,56 +8731,64 @@
                 "name": "White voting age population",
                 "sum": 1562620,
                 "min": 0,
-                "max": 5056
+                "max": 5056,
+                "breaks": [0.0, 0.1941, 0.5457, 0.748, 0.8785, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 15633,
                 "min": 0,
-                "max": 271
+                "max": 271,
+                "breaks": [0.0, 0.0056, 0.016, 0.0361, 0.0801, 0.1425]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 213490,
                 "min": 0,
-                "max": 1510
+                "max": 1510,
+                "breaks": [0.0, 0.0605, 0.1272, 0.2191, 0.3631, 0.7073]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 17598,
                 "min": 0,
-                "max": 757
+                "max": 757,
+                "breaks": [0.0, 0.0456, 0.1786, 0.4634, 0.7833, 0.9801]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 13996,
                 "min": 0,
-                "max": 253
+                "max": 253,
+                "breaks": [0.0, 0.0052, 0.0157, 0.0343, 0.0637, 0.0997]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 40847,
                 "min": 0,
-                "max": 920
+                "max": 920,
+                "breaks": [0.0, 0.0146, 0.0358, 0.0758, 0.1599, 0.2919]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 1805,
                 "min": 0,
-                "max": 84
+                "max": 84,
+                "breaks": [0.0, 0.001, 0.0037, 0.0112, 0.0381, 0.0739]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 20257,
                 "min": 0,
-                "max": 145
+                "max": 145,
+                "breaks": [0.0, 0.0064, 0.0126, 0.0211, 0.0751, 0.1748]
               }
             ]
           },
@@ -8548,7 +8913,8 @@
               "name": "Total population",
               "sum": 178040,
               "min": 0,
-              "max": 1873
+              "max": 1873,
+              "breaks": [0, 42, 125, 307, 710, 1873]
             },
             "subgroups": [
               {
@@ -8556,49 +8922,56 @@
                 "name": "White population",
                 "sum": 66909,
                 "min": 0,
-                "max": 1691
+                "max": 1691,
+                "breaks": [0.0, 0.1053, 0.3091, 0.5461, 0.7879, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 23398,
                 "min": 0,
-                "max": 165
+                "max": 165,
+                "breaks": [0.0, 0.0566, 0.163, 0.2991, 0.5231, 1.0]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 67835,
                 "min": 0,
-                "max": 471
+                "max": 471,
+                "breaks": [0.0, 0.1074, 0.31, 0.5152, 0.7196, 1.0]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 11153,
                 "min": 0,
-                "max": 259
+                "max": 259,
+                "breaks": [0.0, 0.0402, 0.1268, 0.2574, 0.5341, 1.0]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 1220,
                 "min": 0,
-                "max": 17
+                "max": 17,
+                "breaks": [0.0, 0.0106, 0.0385, 0.087, 0.1818, 0.3333]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 88,
                 "min": 0,
-                "max": 7
+                "max": 7,
+                "breaks": [0.0, 0.0075, 0.0222, 0.0417, 0.08, 1.0]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 1727,
                 "min": 0,
-                "max": 46
+                "max": 46,
+                "breaks": [0.0, 0.0222, 0.0833, 0.2105, 0.4, 0.625]
               }
             ]
           },
@@ -8610,7 +8983,8 @@
               "name": "Voting age population",
               "sum": 136406,
               "min": 0,
-              "max": 1872
+              "max": 1872,
+              "breaks": [0, 33, 100, 257, 710, 1872]
             },
             "subgroups": [
               {
@@ -8618,56 +8992,64 @@
                 "name": "White voting age population",
                 "sum": 60172,
                 "min": 0,
-                "max": 1691
+                "max": 1691,
+                "breaks": [0.0, 0.1222, 0.3385, 0.5625, 0.7917, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 16716,
                 "min": 0,
-                "max": 120
+                "max": 120,
+                "breaks": [0.0, 0.0508, 0.1489, 0.2708, 0.4706, 1.0]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 44669,
                 "min": 0,
-                "max": 296
+                "max": 296,
+                "breaks": [0.0, 0.0968, 0.2833, 0.4885, 0.7037, 1.0]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 845,
                 "min": 0,
-                "max": 14
+                "max": 14,
+                "breaks": [0.0, 0.0104, 0.0375, 0.08, 0.1429, 0.3333]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 73,
                 "min": 0,
-                "max": 5
+                "max": 5,
+                "breaks": [0.0, 0.0076, 0.0238, 0.0455, 0.0833, 1.0]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 9058,
                 "min": 0,
-                "max": 259
+                "max": 259,
+                "breaks": [0.0, 0.0357, 0.1136, 0.2391, 0.5278, 1.0]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 1233,
                 "min": 0,
-                "max": 21
+                "max": 21,
+                "breaks": [0.0, 0.0138, 0.0494, 0.1127, 0.2381, 0.5]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 3640,
                 "min": 0,
-                "max": 61
+                "max": 61,
+                "breaks": [0.0, 0.0244, 0.0833, 0.2143, 0.5, 1.0]
               }
             ]
           }
@@ -8864,7 +9246,8 @@
               "name": "Total population",
               "sum": 18714,
               "min": 55,
-              "max": 1940
+              "max": 1940,
+              "breaks": [55, 208, 563, 1014, 1285, 1940]
             },
             "subgroups": [
               {
@@ -8872,56 +9255,64 @@
                 "name": "White population",
                 "sum": 7249,
                 "min": 37,
-                "max": 473
+                "max": 473,
+                "breaks": [0.0648, 0.237, 0.3971, 0.5714, 0.8881, 0.9692]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 41,
                 "min": 0,
-                "max": 15
+                "max": 15,
+                "breaks": [0.0, 0.0018, 0.0048, 0.012, 0.016, 0.0897]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 11085,
                 "min": 1,
-                "max": 1622
+                "max": 1622,
+                "breaks": [0.0061, 0.0727, 0.1325, 0.49, 0.7384, 0.9311]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 88,
                 "min": 0,
-                "max": 19
+                "max": 19,
+                "breaks": [0.0, 0.0, 0.0037, 0.0061, 0.0124, 0.0171]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 65,
                 "min": 0,
-                "max": 13
+                "max": 13,
+                "breaks": [0.0, 0.0027, 0.0067, 0.0112, 0.0182, 0.05]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 2,
                 "min": 0,
-                "max": 1
+                "max": 1,
+                "breaks": [0.0, 0.0, 0.0, 0.0, 0.0006, 0.0048]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 110,
                 "min": 0,
-                "max": 12
+                "max": 12,
+                "breaks": [0.0, 0.0068, 0.0137, 0.0245, 0.0361, 0.08]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 18,
                 "min": 0,
-                "max": 6
+                "max": 6,
+                "breaks": [0.0, 0.0, 0.0025, 0.0031, 0.0034, 0.0057]
               }
             ]
           },
@@ -8933,7 +9324,8 @@
               "name": "Voting age population",
               "sum": 12200,
               "min": 45,
-              "max": 1158
+              "max": 1158,
+              "breaks": [45, 115, 299, 572, 829, 1158]
             },
             "subgroups": [
               {
@@ -8941,56 +9333,64 @@
                 "name": "White voting age population",
                 "sum": 5661,
                 "min": 29,
-                "max": 377
+                "max": 377,
+                "breaks": [0.0758, 0.2544, 0.5072, 0.6802, 0.912, 0.9823]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 13,
                 "min": 0,
-                "max": 5
+                "max": 5,
+                "breaks": [0.0, 0.0009, 0.0049, 0.0066, 0.0175, 0.0222]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 6303,
                 "min": 0,
-                "max": 911
+                "max": 911,
+                "breaks": [0.0, 0.1094, 0.3333, 0.666, 0.7867, 0.9216]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 42,
                 "min": 0,
-                "max": 6
+                "max": 6,
+                "breaks": [0.0, 0.002, 0.0075, 0.0145, 0.0222, 0.0725]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 1,
                 "min": 0,
-                "max": 1
+                "max": 1,
+                "breaks": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0066]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 62,
                 "min": 0,
-                "max": 15
+                "max": 15,
+                "breaks": [0.0, 0.0, 0.0055, 0.0087, 0.0152, 0.0226]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 10,
                 "min": 0,
-                "max": 4
+                "max": 4,
+                "breaks": [0.0, 0.0, 0.001, 0.0025, 0.0048, 0.0062]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 57,
                 "min": 0,
-                "max": 7
+                "max": 7,
+                "breaks": [0.0, 0.0021, 0.0071, 0.0164, 0.0222, 0.0725]
               }
             ]
           }
@@ -9045,7 +9445,8 @@
               "name": "Total population",
               "sum": 18728,
               "min": 0,
-              "max": 677
+              "max": 677,
+              "breaks": [0, 20, 84, 216, 446, 677]
             },
             "subgroups": [
               {
@@ -9053,56 +9454,64 @@
                 "name": "White population",
                 "sum": 7262,
                 "min": 0,
-                "max": 142
+                "max": 142,
+                "breaks": [0.0, 0.125, 0.375, 0.625, 0.8788, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 47,
                 "min": 0,
-                "max": 7
+                "max": 7,
+                "breaks": [0.0, 0.0278, 0.0909, 0.2, 0.5, 1.0]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 11099,
                 "min": 0,
-                "max": 600
+                "max": 600,
+                "breaks": [0.0, 0.125, 0.377, 0.619, 0.8519, 1.0]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 99,
                 "min": 0,
-                "max": 14
+                "max": 14,
+                "breaks": [0.0, 0.04, 0.1667, 0.3333, 0.5, 1.0]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 76,
                 "min": 0,
-                "max": 11
+                "max": 11,
+                "breaks": [0.0, 0.0455, 0.1429, 0.2857, 0.3636, 1.0]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 3,
                 "min": 0,
-                "max": 1
+                "max": 1,
+                "breaks": [0.0, 0.0, 0.0, 0.0049, 0.2, 1.0]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 124,
                 "min": 0,
-                "max": 7
+                "max": 7,
+                "breaks": [0.0, 0.0435, 0.2, 0.4, 0.6, 1.0]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 18,
                 "min": 0,
-                "max": 5
+                "max": 5,
+                "breaks": [0.0, 0.0, 0.0, 0.0, 0.0049, 0.119]
               }
             ]
           },
@@ -9114,7 +9523,8 @@
               "name": "Voting age population",
               "sum": 12216,
               "min": 0,
-              "max": 394
+              "max": 394,
+              "breaks": [0, 12, 54, 148, 261, 394]
             },
             "subgroups": [
               {
@@ -9122,56 +9532,64 @@
                 "name": "White voting age population",
                 "sum": 5676,
                 "min": 0,
-                "max": 119
+                "max": 119,
+                "breaks": [0.0, 0.125, 0.3784, 0.6364, 0.875, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 16,
                 "min": 0,
-                "max": 2
+                "max": 2,
+                "breaks": [0.0, 0.0308, 0.2, 0.3333, 0.5, 1.0]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 6319,
                 "min": 0,
-                "max": 333
+                "max": 333,
+                "breaks": [0.0, 0.1111, 0.3333, 0.5789, 0.8333, 1.0]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 52,
                 "min": 0,
-                "max": 4
+                "max": 4,
+                "breaks": [0.0, 0.0417, 0.125, 0.25, 0.4, 1.0]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 2,
                 "min": 0,
-                "max": 1
+                "max": 1,
+                "breaks": [0.0, 0.0, 0.0, 0.0, 0.3333, 1.0]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 72,
                 "min": 0,
-                "max": 11
+                "max": 11,
+                "breaks": [0.0, 0.0417, 0.1667, 0.3333, 0.5, 1.0]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 10,
                 "min": 0,
-                "max": 4
+                "max": 4,
+                "breaks": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0417]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 69,
                 "min": 0,
-                "max": 4
+                "max": 4,
+                "breaks": [0.0, 0.0435, 0.2, 0.3333, 0.5, 1.0]
               }
             ]
           }
@@ -9320,7 +9738,8 @@
               "name": "Total population",
               "sum": 243156,
               "min": 0,
-              "max": 5039
+              "max": 5039,
+              "breaks": [0, 741, 1535, 2382, 3518, 5039]
             },
             "subgroups": [
               {
@@ -9328,56 +9747,64 @@
                 "name": "White population",
                 "sum": 115952,
                 "min": 0,
-                "max": 1834
+                "max": 1834,
+                "breaks": [0.0, 0.2586, 0.4559, 0.6281, 0.7898, 0.9778]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 1677,
                 "min": 0,
-                "max": 118
+                "max": 118,
+                "breaks": [0.0, 0.0022, 0.0074, 0.0145, 0.0266, 0.0434]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 109400,
                 "min": 0,
-                "max": 4235
+                "max": 4235,
+                "breaks": [0.0, 0.1685, 0.3228, 0.49, 0.6882, 1.0]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 2286,
                 "min": 0,
-                "max": 158
+                "max": 158,
+                "breaks": [0.0, 0.0042, 0.0122, 0.0227, 0.042, 0.063]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 9000,
                 "min": 0,
-                "max": 1621
+                "max": 1621,
+                "breaks": [0.0, 0.0579, 0.1906, 0.3341, 0.4549, 0.6266]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 104,
                 "min": 0,
-                "max": 8
+                "max": 8,
+                "breaks": [0.0, 0.0003, 0.0011, 0.0022, 0.0042, 0.037]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 4022,
                 "min": 0,
-                "max": 87
+                "max": 87,
+                "breaks": [0.0, 0.0101, 0.0202, 0.0316, 0.05, 0.08]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 286,
                 "min": 0,
-                "max": 18
+                "max": 18,
+                "breaks": [0.0, 0.0007, 0.0025, 0.0052, 0.0093, 0.0149]
               }
             ]
           },
@@ -9389,7 +9816,8 @@
               "name": "Voting age population",
               "sum": 169120,
               "min": 0,
-              "max": 3172
+              "max": 3172,
+              "breaks": [0, 488, 1092, 1701, 2386, 3172]
             },
             "subgroups": [
               {
@@ -9397,56 +9825,64 @@
                 "name": "White voting age population",
                 "sum": 93721,
                 "min": 0,
-                "max": 1434
+                "max": 1434,
+                "breaks": [0.0, 0.2153, 0.3995, 0.6189, 0.7993, 0.98]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 1276,
                 "min": 0,
-                "max": 105
+                "max": 105,
+                "breaks": [0.0, 0.0036, 0.0094, 0.02, 0.0351, 0.0523]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 63449,
                 "min": 0,
-                "max": 2515
+                "max": 2515,
+                "breaks": [0.0, 0.1478, 0.2892, 0.44, 0.6419, 0.8947]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 5961,
                 "min": 0,
-                "max": 1006
+                "max": 1006,
+                "breaks": [0.0, 0.0731, 0.2144, 0.3218, 0.434, 0.6104]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 83,
                 "min": 0,
-                "max": 5
+                "max": 5,
+                "breaks": [0.0, 0.0005, 0.0018, 0.0041, 0.0299, 0.0476]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 1757,
                 "min": 0,
-                "max": 114
+                "max": 114,
+                "breaks": [0.0, 0.0055, 0.015, 0.0302, 0.0524, 0.0769]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 169,
                 "min": 0,
-                "max": 13
+                "max": 13,
+                "breaks": [0.0, 0.001, 0.003, 0.0062, 0.0093, 0.0182]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 2262,
                 "min": 0,
-                "max": 48
+                "max": 48,
+                "breaks": [0.0, 0.0052, 0.014, 0.0242, 0.0476, 0.0952]
               }
             ]
           }
@@ -9501,7 +9937,8 @@
               "name": "Total population",
               "sum": 243231,
               "min": 0,
-              "max": 1134
+              "max": 1134,
+              "breaks": [0, 22, 74, 170, 320, 1134]
             },
             "subgroups": [
               {
@@ -9509,56 +9946,64 @@
                 "name": "White population",
                 "sum": 116024,
                 "min": 0,
-                "max": 646
+                "max": 646,
+                "breaks": [0.0, 0.1304, 0.3871, 0.6381, 0.8676, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 1743,
                 "min": 0,
-                "max": 77
+                "max": 77,
+                "breaks": [0.0, 0.0328, 0.1364, 0.3077, 0.625, 1.0]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 109470,
                 "min": 0,
-                "max": 1034
+                "max": 1034,
+                "breaks": [0.0, 0.1136, 0.338, 0.5789, 0.8283, 1.0]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 2359,
                 "min": 0,
-                "max": 40
+                "max": 40,
+                "breaks": [0.0, 0.0194, 0.0784, 0.1667, 0.3913, 1.0]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 9072,
                 "min": 0,
-                "max": 277
+                "max": 277,
+                "breaks": [0.0, 0.087, 0.2895, 0.55, 0.8276, 1.0]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 142,
                 "min": 0,
-                "max": 9
+                "max": 9,
+                "breaks": [0.0, 0.0051, 0.0169, 0.0455, 0.0833, 1.0]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 4090,
                 "min": 0,
-                "max": 27
+                "max": 27,
+                "breaks": [0.0, 0.0299, 0.1176, 0.2857, 0.6667, 1.0]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 331,
                 "min": 0,
-                "max": 11
+                "max": 11,
+                "breaks": [0.0, 0.013, 0.0645, 0.1429, 0.5, 1.0]
               }
             ]
           },
@@ -9570,7 +10015,8 @@
               "name": "Voting age population",
               "sum": 169193,
               "min": 0,
-              "max": 715
+              "max": 715,
+              "breaks": [0, 13, 44, 109, 235, 715]
             },
             "subgroups": [
               {
@@ -9578,56 +10024,64 @@
                 "name": "White voting age population",
                 "sum": 93795,
                 "min": 0,
-                "max": 489
+                "max": 489,
+                "breaks": [0.0, 0.1277, 0.3846, 0.6377, 0.8696, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 1337,
                 "min": 0,
-                "max": 77
+                "max": 77,
+                "breaks": [0.0, 0.0259, 0.125, 0.3333, 0.625, 1.0]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 63528,
                 "min": 0,
-                "max": 549
+                "max": 549,
+                "breaks": [0.0, 0.0968, 0.3077, 0.5581, 0.8261, 1.0]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 6038,
                 "min": 0,
-                "max": 153
+                "max": 153,
+                "breaks": [0.0, 0.0909, 0.3, 0.5385, 0.8, 1.0]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 119,
                 "min": 0,
-                "max": 6
+                "max": 6,
+                "breaks": [0.0, 0.0065, 0.0238, 0.0625, 0.1071, 1.0]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 1829,
                 "min": 0,
-                "max": 34
+                "max": 34,
+                "breaks": [0.0, 0.0175, 0.0714, 0.1818, 0.5, 1.0]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 214,
                 "min": 0,
-                "max": 9
+                "max": 9,
+                "breaks": [0.0, 0.037, 0.1111, 0.2, 0.5, 1.0]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 2333,
                 "min": 0,
-                "max": 14
+                "max": 14,
+                "breaks": [0.0, 0.0392, 0.1579, 0.3333, 0.6667, 1.0]
               }
             ]
           }
@@ -9694,7 +10148,8 @@
               "name": "Total population",
               "sum": 178883,
               "min": 0,
-              "max": 2047
+              "max": 2047,
+              "breaks": [0, 51, 194, 492, 1064, 2047]
             },
             "subgroups": [
               {
@@ -9702,56 +10157,64 @@
                 "name": "White population",
                 "sum": 80740,
                 "min": 0,
-                "max": 1752
+                "max": 1752,
+                "breaks": [0.0, 0.098, 0.315, 0.5833, 0.8429, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 78458,
                 "min": 0,
-                "max": 898
+                "max": 898,
+                "breaks": [0.0, 0.1081, 0.3462, 0.6071, 0.8462, 1.0]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 12598,
                 "min": 0,
-                "max": 407
+                "max": 407,
+                "breaks": [0.0, 0.0548, 0.1951, 0.4194, 0.7358, 1.0]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 3865,
                 "min": 0,
-                "max": 288
+                "max": 288,
+                "breaks": [0.0, 0.0351, 0.1261, 0.3125, 0.6, 1.0]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 468,
                 "min": 0,
-                "max": 11
+                "max": 11,
+                "breaks": [0.0, 0.0068, 0.0278, 0.0769, 0.1667, 0.3333]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 53,
                 "min": 0,
-                "max": 6
+                "max": 6,
+                "breaks": [0.0, 0.0063, 0.0308, 0.0625, 0.2609, 0.2941]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 2443,
                 "min": 0,
-                "max": 43
+                "max": 43,
+                "breaks": [0.0, 0.0267, 0.102, 0.3, 0.625, 1.0]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 258,
                 "min": 0,
-                "max": 12
+                "max": 12,
+                "breaks": [0.0, 0.0111, 0.044, 0.1111, 0.2, 0.3333]
               }
             ]
           },
@@ -9763,7 +10226,8 @@
               "name": "Voting age population",
               "sum": 136533,
               "min": 0,
-              "max": 1581
+              "max": 1581,
+              "breaks": [0, 39, 151, 388, 823, 1581]
             },
             "subgroups": [
               {
@@ -9771,56 +10235,64 @@
                 "name": "White voting age population",
                 "sum": 67993,
                 "min": 0,
-                "max": 1381
+                "max": 1381,
+                "breaks": [0.0, 0.0968, 0.3095, 0.5833, 0.8462, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 55286,
                 "min": 0,
-                "max": 675
+                "max": 675,
+                "breaks": [0.0, 0.1124, 0.3537, 0.6133, 0.8529, 1.0]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 8379,
                 "min": 0,
-                "max": 243
+                "max": 243,
+                "breaks": [0.0, 0.0439, 0.1579, 0.375, 0.7209, 1.0]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 350,
                 "min": 0,
-                "max": 7
+                "max": 7,
+                "breaks": [0.0, 0.0084, 0.0294, 0.0625, 0.125, 0.3333]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 38,
                 "min": 0,
-                "max": 3
+                "max": 3,
+                "breaks": [0.0, 0.0104, 0.0488, 0.0909, 0.1667, 0.2143]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 2998,
                 "min": 0,
-                "max": 216
+                "max": 216,
+                "breaks": [0.0, 0.0316, 0.1176, 0.2857, 0.6, 1.0]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 143,
                 "min": 0,
-                "max": 5
+                "max": 5,
+                "breaks": [0.0, 0.013, 0.0417, 0.0909, 0.2, 0.3333]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 1346,
                 "min": 0,
-                "max": 28
+                "max": 28,
+                "breaks": [0.0, 0.0303, 0.1176, 0.2857, 0.5, 1.0]
               }
             ]
           }
@@ -9884,7 +10356,8 @@
               "name": "Total population",
               "sum": 3830404,
               "min": 0,
-              "max": 17974
+              "max": 17974,
+              "breaks": [0, 1614, 3674, 6359, 10185, 17974]
             },
             "subgroups": [
               {
@@ -9892,56 +10365,64 @@
                 "name": "White population",
                 "sum": 3005164,
                 "min": 0,
-                "max": 12175
+                "max": 12175,
+                "breaks": [0.0, 0.2958, 0.5818, 0.7395, 0.861, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 64442,
                 "min": 0,
-                "max": 2932
+                "max": 2932,
+                "breaks": [0.0, 0.0087, 0.0277, 0.0605, 0.1182, 0.2246]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 449417,
                 "min": 0,
-                "max": 6050
+                "max": 6050,
+                "breaks": [0.0, 0.0674, 0.1382, 0.2525, 0.4446, 0.7912]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 138838,
                 "min": 0,
-                "max": 3337
+                "max": 3337,
+                "breaks": [0.0, 0.0228, 0.061, 0.1137, 0.2064, 0.4367]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 42093,
                 "min": 0,
-                "max": 2692
+                "max": 2692,
+                "breaks": [0.0, 0.0265, 0.0959, 0.2278, 0.4686, 0.8598]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 12278,
                 "min": 0,
-                "max": 217
+                "max": 217,
+                "breaks": [0.0, 0.0023, 0.0077, 0.0159, 0.0345, 0.0598]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 109205,
                 "min": 0,
-                "max": 934
+                "max": 934,
+                "breaks": [0.0, 0.0127, 0.0237, 0.0348, 0.0566, 0.1143]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 5117,
                 "min": 0,
-                "max": 55
+                "max": 55,
+                "breaks": [0.0, 0.0008, 0.0024, 0.0052, 0.0109, 0.0247]
               }
             ]
           },
@@ -9953,7 +10434,8 @@
               "name": "Voting age population",
               "sum": 2963948,
               "min": 0,
-              "max": 13802
+              "max": 13802,
+              "breaks": [0, 1295, 2893, 4985, 7970, 13802]
             },
             "subgroups": [
               {
@@ -9961,56 +10443,64 @@
                 "name": "White voting age population",
                 "sum": 2432193,
                 "min": 0,
-                "max": 10507
+                "max": 10507,
+                "breaks": [0.0, 0.0374, 0.5418, 0.75, 0.8731, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 46424,
                 "min": 0,
-                "max": 2306
+                "max": 2306,
+                "breaks": [0.0, 0.0076, 0.0253, 0.0536, 0.0984, 0.2161]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 269102,
                 "min": 0,
-                "max": 3521
+                "max": 3521,
+                "breaks": [0.0, 0.0564, 0.1208, 0.22, 0.3798, 0.7288]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 31264,
                 "min": 0,
-                "max": 1778
+                "max": 1778,
+                "breaks": [0.0, 0.0252, 0.0937, 0.2122, 0.437, 0.8741]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 8398,
                 "min": 0,
-                "max": 151
+                "max": 151,
+                "breaks": [0.0, 0.002, 0.0064, 0.0132, 0.0248, 0.0506]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 107626,
                 "min": 0,
-                "max": 2068
+                "max": 2068,
+                "breaks": [0.0, 0.0224, 0.0611, 0.1135, 0.2071, 0.4326]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 3414,
                 "min": 0,
-                "max": 43
+                "max": 43,
+                "breaks": [0.0, 0.0007, 0.002, 0.0048, 0.0127, 0.0229]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 61774,
                 "min": 0,
-                "max": 562
+                "max": 562,
+                "breaks": [0.0, 0.0088, 0.0176, 0.0269, 0.0482, 0.1154]
               }
             ]
           },
@@ -10276,7 +10766,8 @@
               "name": "Total population",
               "sum": 11540095,
               "min": 0,
-              "max": 7124
+              "max": 7124,
+              "breaks": [0, 949, 1363, 1840, 3138, 7124]
             },
             "subgroups": [
               {
@@ -10284,56 +10775,64 @@
                 "name": "White population",
                 "sum": 9362223,
                 "min": 0,
-                "max": 6199
+                "max": 6199,
+                "breaks": [0.0, 0.2377, 0.5125, 0.7358, 0.8906, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 1389406,
                 "min": 0,
-                "max": 3189
+                "max": 3189,
+                "breaks": [0.0, 0.077, 0.2342, 0.4601, 0.7362, 0.9906]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 354802,
                 "min": 0,
-                "max": 1370
+                "max": 1370,
+                "breaks": [0.0, 0.0235, 0.0611, 0.1346, 0.2697, 0.5856]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 190840,
                 "min": 0,
-                "max": 1456
+                "max": 1456,
+                "breaks": [0.0, 0.0162, 0.0479, 0.1056, 0.2235, 0.508]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 20907,
                 "min": 0,
-                "max": 30
+                "max": 30,
+                "breaks": [0.0, 0.0009, 0.0023, 0.0044, 0.0081, 0.0227]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 3398,
                 "min": 0,
-                "max": 84
+                "max": 84,
+                "breaks": [0.0, 0.0012, 0.0056, 0.0185, 0.0392, 0.087]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 203341,
                 "min": 0,
-                "max": 180
+                "max": 180,
+                "breaks": [0.0, 0.0098, 0.018, 0.0285, 0.0449, 0.1667]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 15152,
                 "min": 0,
-                "max": 32
+                "max": 32,
+                "breaks": [0.0, 0.0007, 0.0021, 0.0042, 0.0075, 0.0156]
               }
             ]
           },
@@ -10345,7 +10844,8 @@
               "name": "Voting age population",
               "sum": 8808206,
               "min": 0,
-              "max": 6775
+              "max": 6775,
+              "breaks": [0, 747, 1071, 1471, 2893, 6775]
             },
             "subgroups": [
               {
@@ -10353,56 +10853,64 @@
                 "name": "White voting age population",
                 "sum": 7332546,
                 "min": 0,
-                "max": 6134
+                "max": 6134,
+                "breaks": [0.0, 0.2533, 0.5377, 0.751, 0.8992, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 993203,
                 "min": 0,
-                "max": 3134
+                "max": 3134,
+                "breaks": [0.0, 0.0793, 0.2471, 0.482, 0.7549, 0.9901]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 218989,
                 "min": 0,
-                "max": 1301
+                "max": 1301,
+                "breaks": [0.0, 0.024, 0.0711, 0.1579, 0.2952, 0.5641]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 16690,
                 "min": 0,
-                "max": 30
+                "max": 30,
+                "breaks": [0.0, 0.0007, 0.0024, 0.0046, 0.0085, 0.0242]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 2386,
                 "min": 0,
-                "max": 42
+                "max": 42,
+                "breaks": [0.0, 0.0007, 0.0031, 0.0126, 0.0337, 0.0705]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 145554,
                 "min": 0,
-                "max": 1318
+                "max": 1318,
+                "breaks": [0.0, 0.0153, 0.045, 0.0992, 0.2079, 0.499]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 6681,
                 "min": 0,
-                "max": 32
+                "max": 32,
+                "breaks": [0.0, 0.0006, 0.0018, 0.0035, 0.0071, 0.0151]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 92140,
                 "min": 0,
-                "max": 139
+                "max": 139,
+                "breaks": [0.0, 0.0068, 0.0134, 0.0226, 0.0815, 0.1667]
               }
             ]
           },
@@ -10537,7 +11045,8 @@
               "name": "Total population",
               "sum": 3751351,
               "min": 0,
-              "max": 9451
+              "max": 9451,
+              "breaks": [0, 1013, 1996, 3082, 4537, 9451]
             },
             "subgroups": [
               {
@@ -10545,56 +11054,64 @@
                 "name": "White population",
                 "sum": 2575381,
                 "min": 0,
-                "max": 5944
+                "max": 5944,
+                "breaks": [0.0, 0.2977, 0.5422, 0.6964, 0.8149, 1.0]
               },
               {
                 "key": "NH_BLACK",
                 "name": "Black population",
                 "sum": 272071,
                 "min": 0,
-                "max": 3041
+                "max": 3041,
+                "breaks": [0.0, 0.0432, 0.1316, 0.3191, 0.6027, 0.9168]
               },
               {
                 "key": "HISP",
                 "name": "Hispanic population",
                 "sum": 332007,
                 "min": 0,
-                "max": 6523
+                "max": 6523,
+                "breaks": [0.0, 0.0565, 0.1385, 0.2744, 0.4768, 0.725]
               },
               {
                 "key": "NH_ASIAN",
                 "name": "Asian population",
                 "sum": 64154,
                 "min": 0,
-                "max": 718
+                "max": 718,
+                "breaks": [0.0, 0.0117, 0.0349, 0.0797, 0.1701, 0.3535]
               },
               {
                 "key": "NH_AMIN",
                 "name": "American Indian population",
                 "sum": 308733,
                 "min": 0,
-                "max": 1539
+                "max": 1539,
+                "breaks": [0.0, 0.0598, 0.1213, 0.202, 0.3408, 0.7299]
               },
               {
                 "key": "NH_NHPI",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 3977,
                 "min": 0,
-                "max": 230
+                "max": 230,
+                "breaks": [0.0, 0.0016, 0.0065, 0.0235, 0.0543, 0.0969]
               },
               {
                 "key": "NH_2MORE",
                 "name": "Two or more races",
                 "sum": 192074,
                 "min": 0,
-                "max": 628
+                "max": 628,
+                "breaks": [0.0, 0.0266, 0.0469, 0.0686, 0.0985, 0.2041]
               },
               {
                 "key": "NH_OTHER",
                 "name": "Other races",
                 "sum": 2954,
                 "min": 0,
-                "max": 29
+                "max": 29,
+                "breaks": [0.0, 0.0006, 0.002, 0.0047, 0.0102, 0.0316]
               }
             ]
           },
@@ -10606,7 +11123,8 @@
               "name": "Voting age population",
               "sum": 2821685,
               "min": 0,
-              "max": 6764
+              "max": 6764,
+              "breaks": [0, 742, 1452, 2245, 3314, 6764]
             },
             "subgroups": [
               {
@@ -10614,56 +11132,64 @@
                 "name": "White voting age population",
                 "sum": 2055504,
                 "min": 0,
-                "max": 4970
+                "max": 4970,
+                "breaks": [0.0, 0.3262, 0.5881, 0.7334, 0.8403, 1.0]
               },
               {
                 "key": "BVAP",
                 "name": "Black voting age population",
                 "sum": 195546,
                 "min": 0,
-                "max": 2207
+                "max": 2207,
+                "breaks": [0.0, 0.049, 0.1482, 0.3414, 0.6013, 0.9349]
               },
               {
                 "key": "HVAP",
                 "name": "Hispanic voting age population",
                 "sum": 199457,
                 "min": 0,
-                "max": 3931
+                "max": 3931,
+                "breaks": [0.0, 0.0427, 0.1094, 0.2345, 0.4196, 0.76]
               },
               {
                 "key": "AMINVAP",
                 "name": "Native American voting age population",
                 "sum": 207883,
                 "min": 0,
-                "max": 1073
+                "max": 1073,
+                "breaks": [0.0, 0.0657, 0.136, 0.242, 0.4019, 0.7036]
               },
               {
                 "key": "NHPIVAP",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 2701,
                 "min": 0,
-                "max": 133
+                "max": 133,
+                "breaks": [0.0, 0.0011, 0.0049, 0.0156, 0.0455, 0.0713]
               },
               {
                 "key": "ASIANVAP",
                 "name": "Asian voting age population",
                 "sum": 48930,
                 "min": 0,
-                "max": 646
+                "max": 646,
+                "breaks": [0.0, 0.0123, 0.0361, 0.0778, 0.1643, 0.3749]
               },
               {
                 "key": "OTHERVAP",
                 "name": "Other races voting age population",
                 "sum": 1792,
                 "min": 0,
-                "max": 16
+                "max": 16,
+                "breaks": [0.0, 0.0004, 0.0013, 0.0025, 0.0049, 0.0106]
               },
               {
                 "key": "2MOREVAP",
                 "name": "Two or more races voting age population",
                 "sum": 109872,
                 "min": 0,
-                "max": 391
+                "max": 391,
+                "breaks": [0.0, 0.0198, 0.036, 0.0538, 0.0802, 0.1951]
               }
             ]
           },

--- a/breaks.py
+++ b/breaks.py
@@ -1,22 +1,66 @@
-# pip install jenkspy requests
+# pip install jenkspy pyshp requests
 import json
 import jenkspy
 import requests
+import shapefile
 
 # list of MapBox IDs
-communities = [
-    #"chicago_community_areas",
-    #"ma_precincts_02_10",
-    "ma_precincts_12_16",
+web_communities = [
+    # "austin_blocks",
+    # "islip_blocks",
+    # "lowell_blocks",
+    # "ma_towns",
+    # "philadelphia_blocks",
+    # "santa_clara_blocks",
+    # "adams_wa_precincts18",
+    # "adams_wa_blocks",
+    # "yakima_wa_precincts12",
+    # "yakima_wa_blocks",
+    # "little_rock_blocks",
+    # "chicago_community_areas",
+
+    # Are both MA precinct map/eras referring to same ranges?
     #"chicago_precincts"
+
+    # "mississippi_block_groups"
+]
+
+shp_communities = [
+    ## [name of mapbox layer, name of shapefile in parent directory]
+    # ["alaska_precincts", "alaska_precincts"],
+    # ["colorado_precincts", "co_precincts"],
+    # ["iowa_counties", "ia_counties"],
+    # ["georgia_precincts", "GA_precincts16"],
+    # ["maryland_precincts", "MD_precincts"],
+    # ["michigan_precincts", "MI_precincts"],
+    # ["minnesota_precincts", "mn_16"],
+    # -- not precincts, did web scan ["mississippi_block_groups", "ms_"],
+    # ["ma_precincts_12_16", "MA_precincts12_16"],
+    ## VAP missing here? ["ma_precincts_02_10", "MA_precincts_0210"],
+
+    # ["missouri_precincts", "MO_vtds"],
+    # ["new_mexico_precincts", "new_mexico_precincts"],
+    # ["nc_precincts", "NC_VTD"],
+    # ["pennsylvania_precincts", "PA_VTD_PLANS"],
+    # ["texas_precincts", "TX_vtds"],
+    # ["vermont_towns", "VT_town_results"],
+    # ["wisconsin_wards", "WI_ltsb_corrected_final"],
+    # ["virginia_precincts", "VA_precincts"],
+    # ["rhode_island_precincts", "RI_precincts"],
+    # ["providence_ri_blocks", "Providence_blocks"],
+    # ["utah_precincts", "UT_precincts"],
+    # ["oregon_precincts", "OR_precincts"],
+    ["ohio_precincts", "OH_precincts"],
+    ["oklahoma_precincts", "OK_precincts"]
 ]
 public_key = "pk.eyJ1IjoiZGlzdHJpY3RyIiwiYSI6ImNqbjUzMTE5ZTBmcXgzcG81ZHBwMnFsOXYifQ.8HRRLKHEJA0AismGk2SX2g"
 
 # relative path to Districtr response.json
 browser_reference = json.loads(open('./assets/data/response.json', 'r').read())
 
-for comm in communities:
+def get_column_set(comm):
     # find variables used with this community map + unit type
+    columnSet = None
     for mod in browser_reference:
         for unit in mod["units"]:
             if unit["tilesets"][0]["source"]["url"] == "mapbox://districtr." + comm:
@@ -25,6 +69,56 @@ for comm in communities:
     if columnSet is None:
         print("did not find matching map / units for " + comm)
         quit()
+    return columnSet
+
+def output_stuff(comm, total_values_for_var, percent_values_for_var):
+    print(comm)
+    for varsource in [total_values_for_var, percent_values_for_var]:
+        for var in varsource.keys():
+            print(var + ":")
+            calc_breaks = jenkspy.jenks_breaks(varsource[var], nb_class=5)
+            breaks = []
+            for b in calc_breaks:
+                breaks.append(round(b, 4))
+            print('"breaks": ' + str(breaks))
+
+for shpinfo in shp_communities:
+    comm = shpinfo[0]
+    columnSet = get_column_set(comm)
+    total_values_for_var = {}
+    percent_values_for_var = {}
+    total_for_percent = {}
+    for demo_type in columnSet:
+        if "total" in demo_type:
+            total_values_for_var[demo_type["total"]["key"]] = []
+            for subgroup in demo_type["subgroups"]:
+                percent_values_for_var[subgroup["key"]] = []
+                total_for_percent[subgroup["key"]] = demo_type["total"]["key"]
+
+    # gj = json.loads(open("../" + shpinfo[1] + "/" + shpinfo[1] + ".geojson", "r").read())
+    # features = gj["features"]
+    # for feat in features:
+    #     f = feat["properties"]
+
+    sf = shapefile.Reader("../" + shpinfo[1] + "/" + shpinfo[1] + ".geojson")
+    for f in sf.records():
+        # print(f)
+
+        for var in total_values_for_var.keys():
+            total_values_for_var[var].append(int(f[var]))
+        for subvar in percent_values_for_var.keys():
+            if f[total_for_percent[subvar]] == 0:
+                percent_values_for_var[subvar].append(0)
+            else:
+                percent_values_for_var[subvar].append(
+                    f[subvar]
+                    /
+                    f[total_for_percent[subvar]]
+                )
+    output_stuff(comm, total_values_for_var, percent_values_for_var)
+
+for comm in web_communities:
+    columnSet = get_column_set(comm)
 
     # separate out count and percent variables, prepare to record values
     total_values_for_var = {}
@@ -72,24 +166,18 @@ for comm in communities:
                     for var in total_values_for_var.keys():
                         total_values_for_var[var].append(int(f["properties"][var]))
                     for subvar in percent_values_for_var.keys():
-                        percent_values_for_var[subvar].append(
-                            f["properties"][subvar]
-                            /
-                            f["properties"][total_for_percent[subvar]]
-                        )
+                        if f["properties"][total_for_percent[subvar]] == 0:
+                            percent_values_for_var[subvar].append(0)
+                        else:
+                            percent_values_for_var[subvar].append(
+                                f["properties"][subvar]
+                                /
+                                f["properties"][total_for_percent[subvar]]
+                            )
 
             print(str(x) + "," + str(y) + " | total unique units found: " + str(len(seen_ids)))
             # if (len(local_info["features"]) > 0):
             #     print(values_for_var)
             #     quit()
 
-    # output breaks for this community
-    print(comm)
-    for varsource in [total_values_for_var, percent_values_for_var]:
-        for var in varsource.keys():
-            print(var + ":")
-            calc_breaks = jenkspy.jenks_breaks(varsource[var], nb_class=5)
-            breaks = []
-            for b in calc_breaks:
-                breaks.append(round(b, 4))
-            print(breaks)
+    output_stuff(comm, total_values_for_var, percent_values_for_var)

--- a/breaks.py
+++ b/breaks.py
@@ -1,0 +1,95 @@
+# pip install jenkspy requests
+import json
+import jenkspy
+import requests
+
+# list of MapBox IDs
+communities = [
+    #"chicago_community_areas",
+    #"ma_precincts_02_10",
+    "ma_precincts_12_16",
+    #"chicago_precincts"
+]
+public_key = "pk.eyJ1IjoiZGlzdHJpY3RyIiwiYSI6ImNqbjUzMTE5ZTBmcXgzcG81ZHBwMnFsOXYifQ.8HRRLKHEJA0AismGk2SX2g"
+
+# relative path to Districtr response.json
+browser_reference = json.loads(open('./assets/data/response.json', 'r').read())
+
+for comm in communities:
+    # find variables used with this community map + unit type
+    for mod in browser_reference:
+        for unit in mod["units"]:
+            if unit["tilesets"][0]["source"]["url"] == "mapbox://districtr." + comm:
+                columnSet = unit["columnSets"]
+                break
+    if columnSet is None:
+        print("did not find matching map / units for " + comm)
+        quit()
+
+    # separate out count and percent variables, prepare to record values
+    total_values_for_var = {}
+    percent_values_for_var = {}
+    total_for_percent = {}
+    for demo_type in columnSet:
+        if "total" in demo_type:
+            total_values_for_var[demo_type["total"]["key"]] = []
+            for subgroup in demo_type["subgroups"]:
+                percent_values_for_var[subgroup["key"]] = []
+                total_for_percent[subgroup["key"]] = demo_type["total"]["key"]
+    # print(percent_values_for_var)
+    # print(total_values_for_var)
+
+    # layer = layer_info["vector_layers"][0]
+    # vars = layer["fields"].keys()
+    # for var in vars:
+    #     if
+    #         percent_values_for_var[var] = []
+    #     elif
+    #         total_values_for_var[]
+
+    # get the bounds for this map
+    layer_info = requests.get("https://api.mapbox.com/v4/districtr." + comm + ".json?access_token=" + public_key).json()
+    bounds = layer_info["bounds"]
+    xmin = bounds[0]
+    ymin = bounds[1]
+    xmax = bounds[2]
+    ymax = bounds[3]
+
+    # do 16x16 queries within the map bounds
+    # collect as many unique precinct/blocks as possible
+    # record their values so we can make breaks
+    seen_ids = []
+    grid_size = 15
+    for x in range(0, grid_size):
+        for y in range(0, grid_size):
+            lng = str(xmin + (xmax - xmin) * (x / grid_size))
+            lat = str(ymin + (ymax - ymin) * (y / grid_size))
+            local_info = requests.get("https://api.mapbox.com/v4/districtr." + comm + "/tilequery/" + lng + "," + lat + ".json?access_token=" + public_key + "&radius=20000&limit=50").json()
+            # print(local_info)
+            for f in local_info["features"]:
+                if f["id"] not in seen_ids:
+                    seen_ids.append(f["id"])
+                    for var in total_values_for_var.keys():
+                        total_values_for_var[var].append(int(f["properties"][var]))
+                    for subvar in percent_values_for_var.keys():
+                        percent_values_for_var[subvar].append(
+                            f["properties"][subvar]
+                            /
+                            f["properties"][total_for_percent[subvar]]
+                        )
+
+            print(str(x) + "," + str(y) + " | total unique units found: " + str(len(seen_ids)))
+            # if (len(local_info["features"]) > 0):
+            #     print(values_for_var)
+            #     quit()
+
+    # output breaks for this community
+    print(comm)
+    for varsource in [total_values_for_var, percent_values_for_var]:
+        for var in varsource.keys():
+            print(var + ":")
+            calc_breaks = jenkspy.jenks_breaks(varsource[var], nb_class=5)
+            breaks = []
+            for b in calc_breaks:
+                breaks.append(round(b, 4))
+            print(breaks)

--- a/sass/app.scss
+++ b/sass/app.scss
@@ -172,12 +172,6 @@ select {
 
         button {
             cursor: pointer;
-
-            &.close-button {
-                float: right;
-                border: 2px solid #000;
-                font-weight: bold;
-            }
         }
     }
 

--- a/sass/app.scss
+++ b/sass/app.scss
@@ -11,6 +11,7 @@
 @import "components/button";
 @import "components/header-with-toggle";
 @import "components/media";
+@import "components/_legend";
 
 .option-list {
     padding: 0 1rem;

--- a/sass/components/_legend.scss
+++ b/sass/components/_legend.scss
@@ -38,6 +38,10 @@
     .labels {
         display: none;
 
+        &.show-default {
+            display: block;
+        }
+
         .square {
             font-size: 10pt;
         }
@@ -74,5 +78,29 @@
         &:nth-child(6) {
           background: rgba(0, 0, 0, 0.99);
         }
+    }
+
+    &.partisan-legend > .square {
+      // 249, 249, 249 to 25, 118, 210
+      &:nth-child(1) {
+        background: rgba(137, 184, 230, 0.99);
+      }
+      &:nth-child(2) {
+        background: rgba(182, 210, 237, 0.8);
+      }
+      &:nth-child(3) {
+        background: rgba(227, 236, 245, 0.4);
+      }
+      &:nth-child(4) {
+        background: rgba(245, 229, 229, 0.4);
+      }
+      &:nth-child(5) {
+        background: rgba(238, 188, 188, 0.8);
+      }
+      &:nth-child(6) {
+        background: rgba(230, 148, 148, 0.99);
+      }
+      // 249, 249, 249 to 211, 47, 47
+
     }
 }

--- a/sass/components/_legend.scss
+++ b/sass/components/_legend.scss
@@ -48,57 +48,52 @@
     }
 
     .square {
-        width: 40px;
+        width: 48px;
         height: 24px;
         display: inline-block;
+        vertical-align: top;
     }
 
     & > .square {
         width: 24px;
-        margin-left: 8px;
-        margin-right: 8px;
+        margin-left: 12px;
+        margin-right: 12px;
 
         border: 1px solid #444;
 
         &:nth-child(1) {
-          background: rgba(0, 0, 0, 0);
+          background: #fff
         }
         &:nth-child(2) {
-          background: rgba(0, 0, 0, 0.2);
+          background: #f0f0f0;
         }
         &:nth-child(3) {
-          background: rgba(0, 0, 0, 0.4);
+          background: #bdbdbd;
         }
         &:nth-child(4) {
-          background: rgba(0, 0, 0, 0.6);
+          background: #636363;
         }
         &:nth-child(5) {
-          background: rgba(0, 0, 0, 0.8);
-        }
-        &:nth-child(6) {
-          background: rgba(0, 0, 0, 0.99);
+          background: #000
         }
     }
 
     &.partisan-legend > .square {
       // 249, 249, 249 to 25, 118, 210
       &:nth-child(1) {
-        background: rgba(137, 184, 230, 0.99);
+        background: rgba(25, 118, 210, 0.8);
       }
       &:nth-child(2) {
-        background: rgba(182, 210, 237, 0.8);
+        background: rgba(25, 118, 210, 0.4);
       }
       &:nth-child(3) {
-        background: rgba(227, 236, 245, 0.4);
+        background: rgba(249, 249, 249, 0.5);
       }
       &:nth-child(4) {
-        background: rgba(245, 229, 229, 0.4);
+        background: rgba(211, 47, 47, 0.4);
       }
       &:nth-child(5) {
-        background: rgba(238, 188, 188, 0.8);
-      }
-      &:nth-child(6) {
-        background: rgba(230, 148, 148, 0.99);
+        background: rgba(211, 47, 47, 0.8);
       }
       // 249, 249, 249 to 211, 47, 47
 

--- a/sass/components/_legend.scss
+++ b/sass/components/_legend.scss
@@ -37,18 +37,22 @@
 
     .labels {
         display: none;
+
+        .square {
+            font-size: 10pt;
+        }
     }
 
     .square {
-        width: 50px;
-        height: 30px;
+        width: 40px;
+        height: 24px;
         display: inline-block;
     }
 
     & > .square {
-        width: 30px;
-        margin-left: 10px;
-        margin-right: 10px;
+        width: 24px;
+        margin-left: 8px;
+        margin-right: 8px;
 
         border: 1px solid #444;
 
@@ -56,15 +60,18 @@
           background: rgba(0, 0, 0, 0);
         }
         &:nth-child(2) {
-          background: rgba(0, 0, 0, 0.25);
+          background: rgba(0, 0, 0, 0.2);
         }
         &:nth-child(3) {
-          background: rgba(0, 0, 0, 0.5);
+          background: rgba(0, 0, 0, 0.4);
         }
         &:nth-child(4) {
-          background: rgba(0, 0, 0, 0.75);
+          background: rgba(0, 0, 0, 0.6);
         }
         &:nth-child(5) {
+          background: rgba(0, 0, 0, 0.8);
+        }
+        &:nth-child(6) {
           background: rgba(0, 0, 0, 0.99);
         }
     }

--- a/sass/components/_legend.scss
+++ b/sass/components/_legend.scss
@@ -54,6 +54,10 @@
         vertical-align: top;
     }
 
+    .circle {
+        border-radius: 12px;
+    }
+
     & > .square {
         width: 24px;
         margin-left: 12px;

--- a/sass/components/_legend.scss
+++ b/sass/components/_legend.scss
@@ -27,3 +27,45 @@
 .color-scale-continuous {
     background: linear-gradient(to right, rgba(0, 0, 0, 0), black);
 }
+
+.color-legend {
+    text-align: center;
+    margin-left: auto;
+    margin-right: auto;
+    margin-top: 10px;
+    display: none;
+
+    .labels {
+        display: none;
+    }
+
+    .square {
+        width: 50px;
+        height: 30px;
+        display: inline-block;
+    }
+
+    & > .square {
+        width: 30px;
+        margin-left: 10px;
+        margin-right: 10px;
+
+        border: 1px solid #444;
+
+        &:nth-child(1) {
+          background: rgba(0, 0, 0, 0);
+        }
+        &:nth-child(2) {
+          background: rgba(0, 0, 0, 0.25);
+        }
+        &:nth-child(3) {
+          background: rgba(0, 0, 0, 0.5);
+        }
+        &:nth-child(4) {
+          background: rgba(0, 0, 0, 0.75);
+        }
+        &:nth-child(5) {
+          background: rgba(0, 0, 0, 0.99);
+        }
+    }
+}

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -94,13 +94,16 @@ export default class Toolbar {
                     </div>
                     <div id="save-popup">
                         <button
-                            class="close-button"
+                            class="button button--transparent button--icon media__close close-button"
                             @click="${() => {
                                 document.getElementById("save-popup").className = "hide";
                             }}"
                         >
-                            X
+                            <i class="material-icons">
+                                close
+                            </i>
                         </button>
+
                         <strong>Uploaded Plan</strong>
                         You can share your current plan by copying this URL:
                         <code id="code-popup"></code>

--- a/src/layers/LegendLabels.js
+++ b/src/layers/LegendLabels.js
@@ -12,12 +12,23 @@ export function labelPopCount(subgroup) {
 
 export function labelPopPercent(subgroup) {
     let isVAP = subgroup.key.includes("VAP");
+    let cropToDecimal = (num, ending) => {
+        let decimals = 0;
+        if (num > 0) {
+            if (num < 10) {
+                decimals++;
+            }
+            if (num < 1) {
+                decimals++;
+            }
+        }
+        return (ending ? (num - Math.pow(10, -1 * decimals)) : num).toFixed(decimals);
+    };
     // populations to tenths or hundredths of a percent
-    let decimals = (subgroup.breaks[1] <= 0.01) ? 2 : 1;
-    document.querySelectorAll(`#percents-${isVAP ? "vap" : "demographics"} .square`)
+    document.querySelectorAll(`#counts-${isVAP ? "vap" : "demographics"} .square`)
         .forEach((square, index) => {
-            let startPercent = (subgroup.breaks[index] * 100).toFixed(decimals);
-            let endPercent = (subgroup.breaks[index + 1] * 100 - Math.pow(10, -1 * decimals)).toFixed(decimals);
+            let startPercent = cropToDecimal(subgroup.breaks[index] * 100, false);
+            let endPercent = cropToDecimal(subgroup.breaks[index + 1] * 100, index < 4);
 
             square.innerText = startPercent
                 + "-"

--- a/src/layers/LegendLabels.js
+++ b/src/layers/LegendLabels.js
@@ -1,7 +1,7 @@
 let intervalCount = 5;
 
-export function labelZeroToHundredPercent() {
-    document.querySelectorAll("#percents-demographics .square, #percents-vap .square")
+export function labelZeroToHundredPercent(isVAP) {
+    document.querySelectorAll(`#percents-${isVAP ? "vap" : "demographics"} .square`)
         .forEach((square, ind) => {
             let index = ind % intervalCount;
             let percent = (100 / intervalCount * index);
@@ -14,8 +14,8 @@ export function labelZeroToHundredPercent() {
         });
 }
 
-export function labelPopCount(total) {
-    document.querySelectorAll("#counts-demographics .square, #counts-vap .square")
+export function labelPopCount(total, isVAP) {
+    document.querySelectorAll(`#counts-${isVAP ? "vap" : "demographics"} .square`)
         .forEach((sq, ind) => {
             let index = ind % intervalCount;
             // if (index === 0) {
@@ -30,10 +30,10 @@ export function labelPopCount(total) {
     });
 }
 
-export function labelPopPercent(smallpop) {
+export function labelPopPercent(smallpop, isVAP) {
     // populations to tenths or hundredths of a percent
     let decimals = (smallpop > 100) ? 2 : 1;
-    document.querySelectorAll("#percents-demographics .square, #percents-vap .square")
+    document.querySelectorAll(`#percents-${isVAP ? "vap" : "demographics"} .square`)
         .forEach((square, ind) => {
             let index = ind % intervalCount;
             let startPercent = (index * 20 * smallpop).toFixed(index ? decimals : 0);

--- a/src/layers/LegendLabels.js
+++ b/src/layers/LegendLabels.js
@@ -1,50 +1,26 @@
 let intervalCount = 5;
 
-export function labelZeroToHundredPercent(isVAP) {
-    document.querySelectorAll(`#percents-${isVAP ? "vap" : "demographics"} .square`)
-        .forEach((square, ind) => {
-            let index = ind % intervalCount;
-            let percent = (100 / intervalCount * index);
-            if (index === intervalCount - 1) {
-                percent = "≥ " + percent;
-            } else {
-                percent += "-" + (20 * ((index % 5) + 1) - 1);
-            }
-            square.innerText = percent + "%";
-        });
-}
-
-export function labelPopCount(total, isVAP) {
+export function labelPopCount(subgroup) {
+    let isVAP = subgroup.key.includes("VAP");
     document.querySelectorAll(`#counts-${isVAP ? "vap" : "demographics"} .square`)
-        .forEach((sq, ind) => {
-            let index = ind % intervalCount;
-            // if (index === 0) {
-            //     return "≤ " + Math.floor(total * 0.2).toLocaleString();
-            // }
-            // if (index === 4) {
-            //     return "≥ " + Math.floor(total * 0.8).toLocaleString();
-            // }
-            sq.innerText = Math.floor(total * index / intervalCount).toLocaleString()
+        .forEach((sq, index) => {
+            sq.innerText = subgroup.breaks[index].toLocaleString()
                 + "-"
-                + Math.floor(total * (index + 1) / intervalCount - 1).toLocaleString();
+                + (subgroup.breaks[index + 1] - 1).toLocaleString();
     });
 }
 
-export function labelPopPercent(smallpop, isVAP) {
+export function labelPopPercent(subgroup) {
+    let isVAP = subgroup.key.includes("VAP");
     // populations to tenths or hundredths of a percent
-    let decimals = (smallpop > 100) ? 2 : 1;
+    let decimals = (subgroup.breaks[1] <= 0.01) ? 2 : 1;
     document.querySelectorAll(`#percents-${isVAP ? "vap" : "demographics"} .square`)
-        .forEach((square, ind) => {
-            let index = ind % intervalCount;
-            let startPercent = (index * 20 * smallpop).toFixed(index ? decimals : 0);
-            let endPercent = ((index + 1) * 20 * smallpop - Math.pow(10, -1 * decimals)).toFixed(decimals);
+        .forEach((square, index) => {
+            let startPercent = (subgroup.breaks[index] * 100).toFixed(decimals);
+            let endPercent = (subgroup.breaks[index + 1] * 100 - Math.pow(10, -1 * decimals)).toFixed(decimals);
 
-            if (index === intervalCount - 1) {
-                square.innerText = "≥ " + startPercent + "%";
-            } else {
-                square.innerText = startPercent
-                    + "-"
-                    + endPercent + "%";
-            }
+            square.innerText = startPercent
+                + "-"
+                + endPercent + "%";
         });
 }

--- a/src/layers/LegendLabels.js
+++ b/src/layers/LegendLabels.js
@@ -1,0 +1,50 @@
+let intervalCount = 5;
+
+export function labelZeroToHundredPercent() {
+    document.querySelectorAll("#percents-demographics .square, #percents-vap .square")
+        .forEach((square, ind) => {
+            let index = ind % intervalCount;
+            let percent = (100 / intervalCount * index);
+            if (index === intervalCount - 1) {
+                percent = "≥ " + percent;
+            } else {
+                percent += "-" + (20 * ((index % 5) + 1) - 1);
+            }
+            square.innerText = percent + "%";
+        });
+}
+
+export function labelPopCount(total) {
+    document.querySelectorAll("#counts-demographics .square, #counts-vap .square")
+        .forEach((sq, ind) => {
+            let index = ind % intervalCount;
+            // if (index === 0) {
+            //     return "≤ " + Math.floor(total * 0.2).toLocaleString();
+            // }
+            // if (index === 4) {
+            //     return "≥ " + Math.floor(total * 0.8).toLocaleString();
+            // }
+            sq.innerText = Math.floor(total * index / intervalCount).toLocaleString()
+                + "-"
+                + Math.floor(total * (index + 1) / intervalCount - 1).toLocaleString();
+    });
+}
+
+export function labelPopPercent(smallpop) {
+    // populations to tenths or hundredths of a percent
+    let decimals = (smallpop > 100) ? 2 : 1;
+    document.querySelectorAll("#percents-demographics .square, #percents-vap .square")
+        .forEach((square, ind) => {
+            let index = ind % intervalCount;
+            let startPercent = (index * 20 * smallpop).toFixed(index ? decimals : 0);
+            let endPercent = ((index + 1) * 20 * smallpop - Math.pow(10, -1 * decimals)).toFixed(decimals);
+
+            if (index === intervalCount - 1) {
+                square.innerText = "≥ " + startPercent + "%";
+            } else {
+                square.innerText = startPercent
+                    + "-"
+                    + endPercent + "%";
+            }
+        });
+}

--- a/src/layers/Overlay.js
+++ b/src/layers/Overlay.js
@@ -40,7 +40,7 @@ export default class Overlay {
     show() {
         this.hide();
         this.repaint();
-        this.currentLayer.setOpacity(0.8);
+        this.currentLayer.setOpacity(0.6);
         this.visible = true;
     }
     hide() {
@@ -67,7 +67,10 @@ function createLayer(layer) {
         paint: { [`${layer.type}-opacity`]: 0 }
     };
     if (layer.type === 'fill') {
-        layerSpec.paint["fill-outline-color"] = "rgba(120, 120, 120, 0.7)";
+        layerSpec.paint["fill-outline-color"] = "rgba(120, 120, 120, 0)";
+    } else {
+        layerSpec.paint["circle-stroke-color"] = "rgba(120, 120, 120, 0)";
+        layerSpec.paint["circle-stroke-width"] = 0;
     }
     if (layer.sourceLayer !== undefined) {
         layerSpec["source-layer"] = layer.sourceLayer;

--- a/src/layers/Overlay.js
+++ b/src/layers/Overlay.js
@@ -66,6 +66,9 @@ function createLayer(layer) {
         type: layer.type,
         paint: { [`${layer.type}-opacity`]: 0 }
     };
+    if (layer.type === 'fill') {
+        layerSpec.paint["fill-outline-color"] = "rgba(120, 120, 120, 0.7)";
+    }
     if (layer.sourceLayer !== undefined) {
         layerSpec["source-layer"] = layer.sourceLayer;
     }

--- a/src/layers/OverlayContainer.js
+++ b/src/layers/OverlayContainer.js
@@ -69,10 +69,6 @@ export default class OverlayContainer {
             this.overlay.setColorRule(colorByCount);
 
             let total = this.subgroups[i].max;
-            document.querySelectorAll("#counts-" + this._id + " .square").forEach((sq, index) => {
-                sq.innerText = Math.floor(total * index / 5).toLocaleString();
-            });
-
             document.getElementById("counts-" + this._id).style.display = "block";
             document.getElementById("percents-" + this._id).style.display = "none";
         } else {
@@ -113,15 +109,13 @@ export default class OverlayContainer {
                 <span class="square"></span>
                 <span class="square"></span>
                 <span class="square"></span>
-                <span class="square"></span>
                 <br/>
                 <div id="percents-${this._id}" class="labels">
-                    <span class="square">0%</span>
-                    <span class="square">20%</span>
-                    <span class="square">40%</span>
-                    <span class="square">60%</span>
-                    <span class="square">80%</span>
-                    <span class="square">100%</span>
+                    <span class="square">≤ 20%</span>
+                    <span class="square">21-40</span>
+                    <span class="square">41-60</span>
+                    <span class="square">61-80</span>
+                    <span class="square">≥ 81%</span>
                 </div>
                 <div id="counts-${this._id}" class="labels">
                     <span class="square">0</span>
@@ -129,7 +123,6 @@ export default class OverlayContainer {
                     <span class="square">2</span>
                     <span class="square">3</span>
                     <span class="square">4</span>
-                    <span class="square">5</span>
                 </div>
             </div>
         `;

--- a/src/layers/OverlayContainer.js
+++ b/src/layers/OverlayContainer.js
@@ -65,16 +65,13 @@ export default class OverlayContainer {
     changeSubgroup(i) {
         this._currentSubgroupIndex = i;
         this.overlay.setSubgroup(this.subgroups[i]);
+        document.getElementById("counts-" + this._id).style.display = "block";
         if (this.subgroups[i].total === this.subgroups[i]) {
             this.overlay.setColorRule(colorByCount);
 
             let total = this.subgroups[i].max;
-            document.getElementById("counts-" + this._id).style.display = "block";
-            document.getElementById("percents-" + this._id).style.display = "none";
         } else {
             this.overlay.setColorRule(colorByFraction);
-            document.getElementById("counts-" + this._id).style.display = "none";
-            document.getElementById("percents-" + this._id).style.display = "block";
         }
     }
     render() {
@@ -98,8 +95,9 @@ export default class OverlayContainer {
                     ),
                     (i) => {
                         this.overlay.setLayer(i);
-                        document.getElementById("color-" + this._id).style.display
-                            = ((i || !this.overlay.visible) ? "none" : "block");
+                        document.querySelectorAll(`#color-${this._id} > .square`).forEach((sq) => {
+                            sq.className = `square ${i ? 'circle' : 'block'}`;
+                        });
                     }
                 )
             })}
@@ -110,13 +108,6 @@ export default class OverlayContainer {
                 <span class="square"></span>
                 <span class="square"></span>
                 <br/>
-                <div id="percents-${this._id}" class="labels">
-                    <span class="square">≤ 20%</span>
-                    <span class="square">21-40</span>
-                    <span class="square">41-60</span>
-                    <span class="square">61-80</span>
-                    <span class="square">≥ 81%</span>
-                </div>
                 <div id="counts-${this._id}" class="labels">
                     <span class="square">0</span>
                     <span class="square">1</span>

--- a/src/layers/OverlayContainer.js
+++ b/src/layers/OverlayContainer.js
@@ -70,7 +70,7 @@ export default class OverlayContainer {
 
             let total = this.subgroups[i].max;
             document.querySelectorAll("#counts-" + this._id + " .square").forEach((sq, index) => {
-                sq.innerText = Math.floor(total * index / 4).toLocaleString();
+                sq.innerText = Math.floor(total * index / 5).toLocaleString();
             });
 
             document.getElementById("counts-" + this._id).style.display = "block";
@@ -113,12 +113,14 @@ export default class OverlayContainer {
                 <span class="square"></span>
                 <span class="square"></span>
                 <span class="square"></span>
+                <span class="square"></span>
                 <br/>
                 <div id="percents-${this._id}" class="labels">
                     <span class="square">0%</span>
-                    <span class="square">25%</span>
-                    <span class="square">50%</span>
-                    <span class="square">75%</span>
+                    <span class="square">20%</span>
+                    <span class="square">40%</span>
+                    <span class="square">60%</span>
+                    <span class="square">80%</span>
                     <span class="square">100%</span>
                 </div>
                 <div id="counts-${this._id}" class="labels">
@@ -127,6 +129,7 @@ export default class OverlayContainer {
                     <span class="square">2</span>
                     <span class="square">3</span>
                     <span class="square">4</span>
+                    <span class="square">5</span>
                 </div>
             </div>
         `;

--- a/src/layers/OverlayContainer.js
+++ b/src/layers/OverlayContainer.js
@@ -6,7 +6,8 @@ import { colorByCount, colorByFraction } from "./color-rules";
 import Overlay from "./Overlay";
 
 export default class OverlayContainer {
-    constructor(layers, columnSet, toggleText) {
+    constructor(id, layers, columnSet, toggleText) {
+        this._id = id;
         this._currentSubgroupIndex = 0;
         this.subgroups = columnSet.columns;
         // These color rules should be explicitly attached to each subgroup,
@@ -51,8 +52,11 @@ export default class OverlayContainer {
         }
 
         this.visibilityToggle = toggle(toggleText, (this._currentSubgroupIndex !== 0), visible => {
+            document.getElementById("color-" + this._id).style.display
+                = (visible ? "block" : "none");
             if (visible) {
                 this.overlay.show();
+                this.changeSubgroup(this._currentSubgroupIndex);
             } else {
                 this.overlay.hide();
             }
@@ -63,8 +67,18 @@ export default class OverlayContainer {
         this.overlay.setSubgroup(this.subgroups[i]);
         if (this.subgroups[i].total === this.subgroups[i]) {
             this.overlay.setColorRule(colorByCount);
+
+            let total = this.subgroups[i].max;
+            document.querySelectorAll("#counts-" + this._id + " .square").forEach((sq, index) => {
+                sq.innerText = Math.floor(total * index / 4).toLocaleString();
+            });
+
+            document.getElementById("counts-" + this._id).style.display = "block";
+            document.getElementById("percents-" + this._id).style.display = "none";
         } else {
             this.overlay.setColorRule(colorByFraction);
+            document.getElementById("counts-" + this._id).style.display = "none";
+            document.getElementById("percents-" + this._id).style.display = "block";
         }
     }
     render() {
@@ -86,9 +100,35 @@ export default class OverlayContainer {
                     this.overlay.layers.map(layer =>
                         getLayerDescription(layer)
                     ),
-                    i => this.overlay.setLayer(i)
+                    (i) => {
+                        this.overlay.setLayer(i);
+                        document.getElementById("color-" + this._id).style.display
+                            = ((i || !this.overlay.visible) ? "none" : "block");
+                    }
                 )
             })}
+            <div id="color-${this._id}" class="color-legend">
+                <span class="square"></span>
+                <span class="square"></span>
+                <span class="square"></span>
+                <span class="square"></span>
+                <span class="square"></span>
+                <br/>
+                <div id="percents-${this._id}" class="labels">
+                    <span class="square">0%</span>
+                    <span class="square">25%</span>
+                    <span class="square">50%</span>
+                    <span class="square">75%</span>
+                    <span class="square">100%</span>
+                </div>
+                <div id="counts-${this._id}" class="labels">
+                    <span class="square">0</span>
+                    <span class="square">1</span>
+                    <span class="square">2</span>
+                    <span class="square">3</span>
+                    <span class="square">4</span>
+                </div>
+            </div>
         `;
     }
 }

--- a/src/layers/PartisanOverlayContainer.js
+++ b/src/layers/PartisanOverlayContainer.js
@@ -6,7 +6,8 @@ import PartisanOverlay from "./PartisanOverlay";
 import { getLayerDescription } from "./OverlayContainer";
 
 export default class PartisanOverlayContainer {
-    constructor(layers, elections) {
+    constructor(id, layers, elections) {
+        this._id = id;
         this.elections = elections;
         this.layers = layers;
         this.electionOverlays = elections.map(

--- a/src/layers/PartisanOverlayContainer.js
+++ b/src/layers/PartisanOverlayContainer.js
@@ -38,8 +38,8 @@ export default class PartisanOverlayContainer {
     }
     toggleVisibility(visible) {
         this.isVisible = visible;
-        document.getElementById("color-" + this._id).style.display
-            = (visible ? "block" : "none");
+        // document.getElementById("color-" + this._id).style.display
+        //     = (visible ? "block" : "none");
         if (this.isVisible) {
             this.currentElectionOverlay.show();
             this.setElection(this._currentElectionIndex);
@@ -85,8 +85,8 @@ export default class PartisanOverlayContainer {
                     )
                 }
             ].map(Parameter)}
+            <!--
             <div id="color-${this._id}" class="color-legend partisan-legend">
-                <span class="square"></span>
                 <span class="square"></span>
                 <span class="square"></span>
                 <span class="square"></span>
@@ -94,14 +94,14 @@ export default class PartisanOverlayContainer {
                 <span class="square"></span>
                 <br/>
                 <div class="labels show-default">
-                    <span class="square">75% D</span>
-                    <span class="square">65% D</span>
-                    <span class="square">55% D</span>
-                    <span class="square">55% R</span>
-                    <span class="square">65% R</span>
-                    <span class="square">75% R</span>
+                    <span class="square">70+ D</span>
+                    <span class="square">60 D</span>
+                    <span class="square">50-50</span>
+                    <span class="square">60 R</span>
+                    <span class="square">70+ R</span>
                 </div>
             </div>
+            -->
         `;
     }
 }

--- a/src/layers/PartisanOverlayContainer.js
+++ b/src/layers/PartisanOverlayContainer.js
@@ -38,8 +38,11 @@ export default class PartisanOverlayContainer {
     }
     toggleVisibility(visible) {
         this.isVisible = visible;
+        document.getElementById("color-" + this._id).style.display
+            = (visible ? "block" : "none");
         if (this.isVisible) {
             this.currentElectionOverlay.show();
+            this.setElection(this._currentElectionIndex);
         } else {
             this.currentElectionOverlay.hide();
         }
@@ -82,6 +85,23 @@ export default class PartisanOverlayContainer {
                     )
                 }
             ].map(Parameter)}
+            <div id="color-${this._id}" class="color-legend partisan-legend">
+                <span class="square"></span>
+                <span class="square"></span>
+                <span class="square"></span>
+                <span class="square"></span>
+                <span class="square"></span>
+                <span class="square"></span>
+                <br/>
+                <div class="labels show-default">
+                    <span class="square">75% D</span>
+                    <span class="square">65% D</span>
+                    <span class="square">55% D</span>
+                    <span class="square">55% R</span>
+                    <span class="square">65% R</span>
+                    <span class="square">75% R</span>
+                </div>
+            </div>
         `;
     }
 }

--- a/src/layers/color-rules.js
+++ b/src/layers/color-rules.js
@@ -50,7 +50,8 @@ function getPartyRGBColors(name) {
  */
 export function colorByCount(subgroup) {
     let mostPop = subgroup.total.max;
-    labelPopCount(mostPop);
+    let isVAP = subgroup.key.includes("VAP");
+    labelPopCount(mostPop, isVAP);
     return [
         "step",
         subgroup.asMapboxExpression(),
@@ -87,13 +88,14 @@ export function sizeByCount(subgroup) {
  * @returns {Array} Mapbox style for a *-color property
  */
 export function colorByFraction(subgroup) {
+    let isVAP = subgroup.key.includes("VAP");
     let exp = null;
     let smallpop = Math.ceil(subgroup.max / subgroup.total.max * 100) / 100;
     if (smallpop > 0.25) {
-        labelZeroToHundredPercent();
+        labelZeroToHundredPercent(isVAP);
         exp = subgroup.fractionAsMapboxExpression();
     } else {
-        labelPopPercent(smallpop);
+        labelPopPercent(smallpop, isVAP);
         exp = subgroup.fractionAsMapboxExpression(smallpop);
     }
     return [

--- a/src/layers/color-rules.js
+++ b/src/layers/color-rules.js
@@ -92,11 +92,11 @@ export function colorByFraction(subgroup) {
         "step",
         subgroup.fractionAsMapboxExpression(),
         "rgba(255, 255, 0, 0.5)", // null area
-        0, "rgba(255, 255, 255, 0.8)",
-        subgroup.breaks[1], "rgba(240, 240, 240, 0.8)",
-        subgroup.breaks[2], "rgba(189, 189, 189, 0.8)",
-        subgroup.breaks[3], "rgba(99, 99, 99, 0.8)",
-        subgroup.breaks[4], "rgba(0, 0, 0, 0.8)", // up to 100% or (for small groups) estimated max %
+        0, "rgb(255, 255, 255)",
+        subgroup.breaks[1], "rgb(240, 240, 240)",
+        subgroup.breaks[2], "rgb(189, 189, 189)",
+        subgroup.breaks[3], "rgb(99, 99, 99)",
+        subgroup.breaks[4], "rgb(0, 0, 0)", // up to 100% or (for small groups) estimated max %
     ];
 }
 

--- a/src/layers/color-rules.js
+++ b/src/layers/color-rules.js
@@ -49,18 +49,16 @@ function getPartyRGBColors(name) {
  * @returns {Array} Mapbox style for a *-color property
  */
 export function colorByCount(subgroup) {
-    let mostPop = subgroup.total.max;
-    let isVAP = subgroup.key.includes("VAP");
-    labelPopCount(mostPop, isVAP);
+    labelPopCount(subgroup);
     return [
         "step",
         subgroup.asMapboxExpression(),
         "#f00",
         0, "#fff",
-        mostPop * 0.2, "#f0f0f0",
-        mostPop * 0.4, "#bdbdbd",
-        mostPop * 0.6, "#636363",
-        mostPop * 0.8, "#000", // up to 100% of mostPop
+        subgroup.breaks[1], "#f0f0f0",
+        subgroup.breaks[2], "#bdbdbd",
+        subgroup.breaks[3], "#636363",
+        subgroup.breaks[4], "#000", // up to 100% of mostPop
     ];
 }
 
@@ -88,25 +86,17 @@ export function sizeByCount(subgroup) {
  * @returns {Array} Mapbox style for a *-color property
  */
 export function colorByFraction(subgroup) {
-    let isVAP = subgroup.key.includes("VAP");
-    let exp = null;
     let smallpop = Math.ceil(subgroup.max / subgroup.total.max * 100) / 100;
-    if (smallpop > 0.25) {
-        labelZeroToHundredPercent(isVAP);
-        exp = subgroup.fractionAsMapboxExpression();
-    } else {
-        labelPopPercent(smallpop, isVAP);
-        exp = subgroup.fractionAsMapboxExpression(smallpop);
-    }
+    labelPopPercent(subgroup);
     return [
         "step",
-        exp,
-        "#ff0", // null area
-        0, "#fff",
-        0.2, "#f0f0f0",
-        0.4, "#bdbdbd",
-        0.6, "#636363",
-        0.8, "#000", // up to 100% or (for small groups) estimated max %
+        subgroup.fractionAsMapboxExpression(),
+        "rgba(255, 255, 0, 0.5)", // null area
+        0, "rgba(255, 255, 255, 0.8)",
+        subgroup.breaks[1], "rgba(240, 240, 240, 0.8)",
+        subgroup.breaks[2], "rgba(189, 189, 189, 0.8)",
+        subgroup.breaks[3], "rgba(99, 99, 99, 0.8)",
+        subgroup.breaks[4], "rgba(0, 0, 0, 0.8)", // up to 100% or (for small groups) estimated max %
     ];
 }
 

--- a/src/map/Layer.js
+++ b/src/map/Layer.js
@@ -65,6 +65,12 @@ export default class Layer {
     }
     setOpacity(opacity) {
         this.setPaintProperty(`${this.type}-opacity`, opacity);
+        if (this.type === "fill") {
+            this.setPaintProperty("fill-outline-color", `rgba(120, 120, 120, ${opacity})`);
+        } else {
+            this.setPaintProperty("circle-stroke-color", `rgba(120, 120, 120, ${opacity})`);
+            this.setPaintProperty("circle-stroke-width", opacity ? 1 : 0);
+        }
     }
     setColor(color) {
         this.setPaintProperty(`${this.type}-color`, color);

--- a/src/models/NumericalColumn.js
+++ b/src/models/NumericalColumn.js
@@ -18,8 +18,12 @@ export default class NumericalColumn {
     formatValue(feature) {
         return numberWithCommas(this.getValue(feature));
     }
-    asMapboxExpression() {
-        return ["to-number", ["get", this.key]];
+    asMapboxExpression(smallpop) {
+        if (smallpop) {
+            return ["*", this.asMapboxExpression(), (1 / smallpop)];
+        } else {
+            return ["to-number", ["get", this.key]];
+        }
     }
 }
 

--- a/src/models/NumericalColumn.js
+++ b/src/models/NumericalColumn.js
@@ -7,6 +7,7 @@ export default class NumericalColumn {
         this.sum = columnRecord.sum;
         this.min = columnRecord.min;
         this.max = columnRecord.max;
+        this.breaks = columnRecord.breaks;
 
         this.getValue = this.getValue.bind(this);
         this.formatValue = this.formatValue.bind(this);

--- a/src/models/Subgroup.js
+++ b/src/models/Subgroup.js
@@ -29,9 +29,9 @@ export class Subgroup extends NumericalColumn {
         const total = this.total.sum;
         return total > 0 ? this.sum / total : 0;
     }
-    fractionAsMapboxExpression() {
+    fractionAsMapboxExpression(smallpop) {
         return divideOrZeroIfNaN(
-            this.asMapboxExpression(),
+            this.asMapboxExpression(smallpop),
             this.total.asMapboxExpression()
         );
     }

--- a/src/plugins/data-layers-plugin.js
+++ b/src/plugins/data-layers-plugin.js
@@ -94,6 +94,7 @@ export default function DataLayersPlugin(editor) {
     // that determine what is rendered.
 
     const demographicsOverlay = new OverlayContainer(
+        "demographics",
         state.layers,
         state.population,
         "Show demographics"
@@ -108,6 +109,7 @@ export default function DataLayersPlugin(editor) {
 
     if (state.vap) {
         const vapOverlays = new OverlayContainer(
+            "vap",
             state.layers,
             state.vap,
             "Show VAP demographics"
@@ -123,6 +125,7 @@ export default function DataLayersPlugin(editor) {
 
     if (state.elections.length > 0) {
         const partisanOverlays = new PartisanOverlayContainer(
+            "partisan",
             state.layers,
             state.elections
         );

--- a/validate.js
+++ b/validate.js
@@ -315,6 +315,20 @@ function validateCSentry(columnSet, field, columnSetIndex, unitIndex, planId) {
             process.exit(1);
         }
     });
+    if (columnSet.type !== "election") {
+        if (!columnData.breaks || columnData.breaks.length !== 6) {
+            console.error(planId + " is missing breaks array of 6 values");
+            process.exit(1);
+        }
+        let last = 0;
+        columnData.breaks.forEach(brk => {
+            if (brk < last) {
+                console.error(planId + " has a value out of order in its breaks array");
+                process.exit(1);
+            }
+            last = brk;
+        });
+    }
 }
 
 validateFile();

--- a/validate.js
+++ b/validate.js
@@ -110,7 +110,7 @@ async function validateUnits(unit, index, plan) {
     });
     if (!fs.existsSync("assets/about/" + plan.id + "/" + unit.id + ".html")) {
         console.error(plan.id + " has no about section for its units (" + unit.id + ")");
-        if (!["minnesota", "providence_ri", "adams_wa", "yakima_wa", "little_rock"].includes(plan.id)) {
+        if (!["adams_wa", "yakima_wa"].includes(plan.id)) {
             process.exit(1);
         }
     }


### PR DESCRIPTION
(updated) This started as a recommendation from users, and it turned out I didn't truly understand the shading on the map either.

On the Data Layers tab, when you check "Show demographics" or "Show VAP", you'll see five grayscale squares with the precinct colors.  These are step breaks based on Jenks natural breaks. I've added a Python script which calculates these breaks from a shapefile or a MapBox layer

Partisan lean and circle layers are unchanged

This is a first pass, so I don't have a legend for the circles.