### PR TITLE
Undo/redo feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
         "d3-scale-chromatic": "^1.5.0",
         "d3-selection": "^1.4.0",
         "d3-transition": "^1.2.0",
+        "hotkeys-js": "^3.7.3",
         "lit-html": "^1.1.2",
         "mapbox-gl": "^1.3.1"
     }

--- a/sass/components/_button.scss
+++ b/sass/components/_button.scss
@@ -42,13 +42,13 @@
     background: $mggg-dark-blue;
 }
 
-.button--green {
-    background-color: #00cd99;
+.button--blank {
+    background: #f9f9f9;
+    border: 1px solid #666;
 }
-
-.button--green:hover,
-.button--green:active {
-    background: #009c6b;
+.button--blank:hover,
+.button--blank:active {
+    background: #aaa;
 }
 
 .button--transparent {

--- a/sass/components/_button.scss
+++ b/sass/components/_button.scss
@@ -46,6 +46,9 @@
     background: #f9f9f9;
     border: 1px solid #666;
 }
+.button--blank[disabled] i {
+    color: #ccc !important;
+}
 .button--blank:hover,
 .button--blank:active {
     background: #aaa;

--- a/sass/components/_button.scss
+++ b/sass/components/_button.scss
@@ -42,6 +42,15 @@
     background: $mggg-dark-blue;
 }
 
+.button--green {
+    background-color: #00cd99;
+}
+
+.button--green:hover,
+.button--green:active {
+    background: #009c6b;
+}
+
 .button--transparent {
     background: none;
     color: $mggg-blue;

--- a/sass/components/_toolbar.scss
+++ b/sass/components/_toolbar.scss
@@ -283,6 +283,11 @@ li:first-child > input:checked ~ .tabs__tab {
     justify-content: space-between;
     align-items: center;
     margin: 0.5rem 0;
+
+    &.undoredo-option {
+        padding-top: 8px;
+        border-top:1px solid silver;
+    }
 }
 
 .ui-option--slim {

--- a/src/components/Toolbar/BrushTool.js
+++ b/src/components/Toolbar/BrushTool.js
@@ -87,10 +87,10 @@ class BrushToolOptions {
                 ? BrushColorPicker(this.colors, this.selectColor, activeColor)
                 : ""}
             ${BrushSlider(this.brush.radius, this.changeRadius)}
-            ${UndoRedo(this.brush)}
             ${this.colors.length > 1
                 ? BrushLock(this.brush.locked, this.toggleBrushLock)
                 : ""}
+            ${UndoRedo(this.brush)}
         `;
     }
 }

--- a/src/components/Toolbar/BrushTool.js
+++ b/src/components/Toolbar/BrushTool.js
@@ -3,6 +3,7 @@ import hotkeys from 'hotkeys-js';
 
 import BrushColorPicker from "./BrushColorPicker";
 import BrushSlider from "./BrushSlider";
+import UndoRedo from "./UndoRedo";
 import Tool from "./Tool";
 
 const icon = (active, colorId, colors) => {
@@ -81,30 +82,15 @@ class BrushToolOptions {
     }
     render() {
         const activeColor = this.colors[this.brush.color].id;
-        let undo = this.brush.undo,
-            redo = this.brush.redo;
         return html`
             ${this.colors.length > 1
                 ? BrushColorPicker(this.colors, this.selectColor, activeColor)
                 : ""}
             ${BrushSlider(this.brush.radius, this.changeRadius)}
+            ${UndoRedo(this.brush.undo, this.brush.redo)}
             ${this.colors.length > 1
                 ? BrushLock(this.brush.locked, this.toggleBrushLock)
                 : ""}
-            <button
-                class="button button--alternate"
-                @click="${redo}"
-                style="float:right;margin-bottom:8px;"
-            >
-                Redo
-            </button>
-            <button
-                class="button button--alternate"
-                @click="${undo}"
-                style="float:right;margin-bottom:8px;"
-            >
-                Undo
-            </button>
         `;
     }
 }

--- a/src/components/Toolbar/BrushTool.js
+++ b/src/components/Toolbar/BrushTool.js
@@ -35,7 +35,7 @@ export default class BrushTool extends Tool {
             this.brush.undo();
             evt.preventDefault();
         });
-        hotkeys(`ctrl+y,command+y,control+y`, (evt, handler) => {
+        hotkeys(`ctrl+shift+z,command+shift+z,control+shift+z`, (evt, handler) => {
             // redo
             this.brush.redo();
             evt.preventDefault();
@@ -81,7 +81,8 @@ class BrushToolOptions {
     }
     render() {
         const activeColor = this.colors[this.brush.color].id;
-        let undo = this.brush.undo;
+        let undo = this.brush.undo,
+            redo = this.brush.redo;
         return html`
             ${this.colors.length > 1
                 ? BrushColorPicker(this.colors, this.selectColor, activeColor)
@@ -90,6 +91,13 @@ class BrushToolOptions {
             ${this.colors.length > 1
                 ? BrushLock(this.brush.locked, this.toggleBrushLock)
                 : ""}
+            <button
+                class="button button--alternate"
+                @click="${redo}"
+                style="float:right;margin-bottom:8px;"
+            >
+                Redo
+            </button>
             <button
                 class="button button--alternate"
                 @click="${undo}"

--- a/src/components/Toolbar/BrushTool.js
+++ b/src/components/Toolbar/BrushTool.js
@@ -64,6 +64,7 @@ class BrushToolOptions {
     }
     render() {
         const activeColor = this.colors[this.brush.color].id;
+        let undo = this.brush.undo;
         return html`
             ${this.colors.length > 1
                 ? BrushColorPicker(this.colors, this.selectColor, activeColor)
@@ -72,6 +73,13 @@ class BrushToolOptions {
             ${this.colors.length > 1
                 ? BrushLock(this.brush.locked, this.toggleBrushLock)
                 : ""}
+            <button
+                class="button button--alternate"
+                @click="${undo}"
+                style="float:right;margin-bottom:8px;"
+            >
+                Undo
+            </button>
         `;
     }
 }

--- a/src/components/Toolbar/BrushTool.js
+++ b/src/components/Toolbar/BrushTool.js
@@ -1,4 +1,6 @@
 import { html } from "lit-html";
+import hotkeys from 'hotkeys-js';
+
 import BrushColorPicker from "./BrushColorPicker";
 import BrushSlider from "./BrushSlider";
 import Tool from "./Tool";
@@ -23,6 +25,21 @@ export default class BrushTool extends Tool {
         this.brush = brush;
         this.colors = colors;
         this.options = new BrushToolOptions(brush, colors);
+
+        hotkeys.filter = ({ target }) => {
+            return (!["INPUT", "TEXTAREA"].includes(target.tagName)
+              || (target.tagName === 'INPUT' && target.type.toLowerCase() !== 'text'));
+        };
+        hotkeys(`ctrl+z,command+z,control+z`, (evt, handler) => {
+            // undo
+            this.brush.undo();
+            evt.preventDefault();
+        });
+        hotkeys(`ctrl+y,command+y,control+y`, (evt, handler) => {
+            // redo
+            this.brush.redo();
+            evt.preventDefault();
+        });
     }
     activate() {
         super.activate();

--- a/src/components/Toolbar/BrushTool.js
+++ b/src/components/Toolbar/BrushTool.js
@@ -87,7 +87,7 @@ class BrushToolOptions {
                 ? BrushColorPicker(this.colors, this.selectColor, activeColor)
                 : ""}
             ${BrushSlider(this.brush.radius, this.changeRadius)}
-            ${UndoRedo(this.brush.undo, this.brush.redo)}
+            ${UndoRedo(this.brush)}
             ${this.colors.length > 1
                 ? BrushLock(this.brush.locked, this.toggleBrushLock)
                 : ""}

--- a/src/components/Toolbar/EraserTool.js
+++ b/src/components/Toolbar/EraserTool.js
@@ -43,7 +43,7 @@ class EraserToolOptions {
             ${BrushSlider(this.brush.radius, this.changeRadius, {
                 title: "Eraser Size"
             })}
-            ${UndoRedo(this.brush.undo, this.brush.redo)}
+            ${UndoRedo(this.brush)}
         `;
     }
 }

--- a/src/components/Toolbar/EraserTool.js
+++ b/src/components/Toolbar/EraserTool.js
@@ -38,10 +38,18 @@ class EraserToolOptions {
         this.renderToolbar();
     }
     render() {
+        let undo = this.brush.undo;
         return html`
             ${BrushSlider(this.brush.radius, this.changeRadius, {
                 title: "Eraser Size"
             })}
+            <button
+                class="button button--alternate"
+                @click="${undo}"
+                style="float:right;margin-bottom:8px;"
+            >
+                Undo
+            </button>
         `;
     }
 }

--- a/src/components/Toolbar/EraserTool.js
+++ b/src/components/Toolbar/EraserTool.js
@@ -38,11 +38,19 @@ class EraserToolOptions {
         this.renderToolbar();
     }
     render() {
-        let undo = this.brush.undo;
+        let undo = this.brush.undo,
+            redo = this.brush.redo;
         return html`
             ${BrushSlider(this.brush.radius, this.changeRadius, {
                 title: "Eraser Size"
             })}
+            <button
+                class="button button--alternate"
+                @click="${redo}"
+                style="float:right;margin-bottom:8px;"
+            >
+                Redo
+            </button>
             <button
                 class="button button--alternate"
                 @click="${undo}"

--- a/src/components/Toolbar/EraserTool.js
+++ b/src/components/Toolbar/EraserTool.js
@@ -1,5 +1,6 @@
 import { html } from "lit-html";
 import BrushSlider from "./BrushSlider";
+import UndoRedo from "./UndoRedo";
 import Tool from "./Tool";
 
 export default class EraserTool extends Tool {
@@ -38,26 +39,11 @@ class EraserToolOptions {
         this.renderToolbar();
     }
     render() {
-        let undo = this.brush.undo,
-            redo = this.brush.redo;
         return html`
             ${BrushSlider(this.brush.radius, this.changeRadius, {
                 title: "Eraser Size"
             })}
-            <button
-                class="button button--alternate"
-                @click="${redo}"
-                style="float:right;margin-bottom:8px;"
-            >
-                Redo
-            </button>
-            <button
-                class="button button--alternate"
-                @click="${undo}"
-                style="float:right;margin-bottom:8px;"
-            >
-                Undo
-            </button>
+            ${UndoRedo(this.brush.undo, this.brush.redo)}
         `;
     }
 }

--- a/src/components/Toolbar/UndoRedo.js
+++ b/src/components/Toolbar/UndoRedo.js
@@ -1,25 +1,23 @@
 import { html } from "lit-html";
 
 export default (undo, redo) => html`
-    <div class="ui-option">
+    <div class="ui-option" style="padding-top:8px">
         <legend class="ui-label ui-label--row">
             Undo / Redo
         </legend>
-        <div class="slider-container">
+        <div style="text-align: center;width:100%;">
             <button
                 class="button undo-redo"
                 @click="${undo}"
                 style="margin-right:8px"
             >
-                <i class="material-icons" style="color: #000;font-size:16px;">undo</i>
-                Undo
+                <i class="material-icons" style="color: #000;font-size:18px;">undo</i>
             </button>
             <button
                 class="button button--green"
                 @click="${redo}"
             >
-                <i class="material-icons" style="color: #000;font-size:16px;">redo</i>
-                Redo
+                <i class="material-icons" style="color: #000;font-size:18px;">redo</i>
             </button>
         </div>
     </div>

--- a/src/components/Toolbar/UndoRedo.js
+++ b/src/components/Toolbar/UndoRedo.js
@@ -1,0 +1,26 @@
+import { html } from "lit-html";
+
+export default (undo, redo) => html`
+    <div class="ui-option">
+        <legend class="ui-label ui-label--row">
+            Undo / Redo
+        </legend>
+        <div class="slider-container">
+            <button
+                class="button undo-redo"
+                @click="${undo}"
+                style="margin-right:8px"
+            >
+                <i class="material-icons" style="color: #000;font-size:16px;">undo</i>
+                Undo
+            </button>
+            <button
+                class="button button--green"
+                @click="${redo}"
+            >
+                <i class="material-icons" style="color: #000;font-size:16px;">redo</i>
+                Redo
+            </button>
+        </div>
+    </div>
+`;

--- a/src/components/Toolbar/UndoRedo.js
+++ b/src/components/Toolbar/UndoRedo.js
@@ -7,14 +7,14 @@ export default (undo, redo) => html`
         </legend>
         <div style="text-align: center;width:100%;">
             <button
-                class="button undo-redo"
+                class="button button--blank"
                 @click="${undo}"
                 style="margin-right:8px"
             >
                 <i class="material-icons" style="color: #000;font-size:18px;">undo</i>
             </button>
             <button
-                class="button button--green"
+                class="button button--blank"
                 @click="${redo}"
             >
                 <i class="material-icons" style="color: #000;font-size:18px;">redo</i>

--- a/src/components/Toolbar/UndoRedo.js
+++ b/src/components/Toolbar/UndoRedo.js
@@ -1,24 +1,52 @@
 import { html } from "lit-html";
 
-export default (undo, redo) => html`
-    <div class="ui-option" style="padding-top:8px">
-        <legend class="ui-label ui-label--row">
-            Undo / Redo
-        </legend>
-        <div style="text-align: center;width:100%;">
-            <button
-                class="button button--blank"
-                @click="${undo}"
-                style="margin-right:8px"
-            >
-                <i class="material-icons" style="color: #000;font-size:18px;">undo</i>
-            </button>
-            <button
-                class="button button--blank"
-                @click="${redo}"
-            >
-                <i class="material-icons" style="color: #000;font-size:18px;">redo</i>
-            </button>
+export default (brush) => {
+    // enable/disable the undo/redo buttons if we're at the end of the undo stack
+    const brush_id = "brush_" + brush.id;
+    brush.on("undo", (endOfStack) => {
+        document.getElementById(`redo_${brush_id}`).disabled = false;
+        if (endOfStack) {
+            document.getElementById(`undo_${brush_id}`).disabled = true;
+        }
+    });
+    brush.on("redo", (endOfStack) => {
+        document.getElementById(`undo_${brush_id}`).disabled = false;
+        if (endOfStack) {
+            document.getElementById(`redo_${brush_id}`).disabled = true;
+        }
+    });
+    brush.on("colorop", (undo_redo_mode) => {
+        // if I add paint, I can undo it, and it's no longer possible to redo previous actions
+        // let undo and redo functions handle whether their buttons are disabled
+        if (!undo_redo_mode) {
+            document.getElementById(`undo_${brush_id}`).disabled = false;
+            document.getElementById(`redo_${brush_id}`).disabled = true;
+        }
+    });
+    return html`
+        <div class="ui-option" style="padding-top:8px">
+            <legend class="ui-label ui-label--row">
+                Undo / Redo
+            </legend>
+            <div style="text-align: center;width:100%;">
+                <button
+                    id="undo_${brush_id}"
+                    class="button button--blank"
+                    @click="${brush.undo}"
+                    style="margin-right:8px"
+                    disabled
+                >
+                    <i class="material-icons" style="color: #000;font-size:18px;">undo</i>
+                </button>
+                <button
+                    id="redo_${brush_id}"
+                    class="button button--blank"
+                    @click="${brush.redo}"
+                    disabled
+                >
+                    <i class="material-icons" style="color: #000;font-size:18px;">redo</i>
+                </button>
+            </div>
         </div>
-    </div>
-`;
+    `;
+}

--- a/src/components/Toolbar/UndoRedo.js
+++ b/src/components/Toolbar/UndoRedo.js
@@ -24,7 +24,7 @@ export default (brush) => {
         }
     });
     return html`
-        <div class="ui-option" style="padding-top:8px">
+        <div class="ui-option undoredo-option">
             <legend class="ui-label ui-label--row">
                 Undo / Redo
             </legend>

--- a/src/map/Brush.js
+++ b/src/map/Brush.js
@@ -5,6 +5,7 @@ export default class Brush extends HoverWithRadius {
     constructor(layer, radius, color) {
         super(layer, radius);
 
+        this.id = Math.random();
         this.color = color;
         this.coloring = false;
         this.locked = false;
@@ -12,7 +13,9 @@ export default class Brush extends HoverWithRadius {
         this.listeners = {
             colorend: [],
             colorfeature: [],
-            colorop: []
+            colorop: [],
+            undo: [],
+            redo: []
         };
         bindAll(["onMouseDown", "onMouseUp", "onClick", "onTouchStart", "undo", "redo", "clearUndo"],
             this);
@@ -167,7 +170,10 @@ export default class Brush extends HoverWithRadius {
 
         // locally store plan state
         for (let listener of this.listeners.colorend.concat(this.listeners.colorop)) {
-            listener();
+            listener(true);
+        }
+        for (let listener of this.listeners.undo) {
+            listener(this.cursorUndo <= 0);
         }
     }
     redo() {
@@ -210,7 +216,10 @@ export default class Brush extends HoverWithRadius {
 
         // locally store plan state
         for (let listener of this.listeners.colorend.concat(this.listeners.colorop)) {
-            listener();
+            listener(true);
+        }
+        for (let listener of this.listeners.redo) {
+            listener(this.cursorUndo >= this.trackUndo.length - 1);
         }
     }
     activate() {

--- a/src/map/Brush.js
+++ b/src/map/Brush.js
@@ -114,7 +114,7 @@ export default class Brush extends HoverWithRadius {
         }
 
         // limit number of changes in the stack
-        if (this.trackUndo.length > 9) {
+        if (this.trackUndo.length > 19) {
             this.trackUndo = this.trackUndo.slice(1);
         }
 

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -14,7 +14,7 @@ export default function ToolsPlugin(editor) {
     brush.on("colorfeature", state.update);
     brush.on("colorend", state.render);
     brush.on("colorend", toolbar.unsave);
-    brush.on("colorend", () => {
+    brush.on("colorop", () => {
         savePlanToStorage(state.serialize());
     });
 


### PR DESCRIPTION
This adds an "Undo" button to Paint and Erase tools.  It remembers only your most recent action (one click and drag). Test that it updates your visible map, saved plan, population count, and demographics

Why work-in-progress:
- UI consensus 
- disabling button when undo is not possible
- adding redo?
- adding more history to undo/redo