### PR TITLE
Small fixes: About popup, Overall election numbers

### DIFF
--- a/src/components/Charts/ElectionResults.js
+++ b/src/components/Charts/ElectionResults.js
@@ -42,6 +42,10 @@ export default function ElectionResults(election, parts) {
         label: part.renderLabel(),
         entries: election.parties.map(party => getCell(party, part))
     }));
+    rows.push({
+        label: "Overall",
+        entries: election.parties.map(party => getCell(party, null))
+    });
     // rows.push({
     // label: "Overall",
     // entries: election.parties.map(party => getCell(party))

--- a/src/components/Charts/ElectionResults.js
+++ b/src/components/Charts/ElectionResults.js
@@ -52,6 +52,7 @@ export default function ElectionResults(election, parts) {
     // });
     return html`
         <h4>${election.name}</h4>
+        <strong>two-party vote share</strong>
         ${DataTable(headers, rows)}
     `;
 }

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -176,7 +176,7 @@ function DropdownMenu(options, open) {
                         <li
                             id="${option.id || ""}"
                             class="ui-list__item"
-                            @click=${option.onClick}
+                            @click=${open ? option.onClick : null}
                         >
                             ${option.name}
                         </li>


### PR DESCRIPTION
- I couldn't repeat the About popup issue, but I changed how the About link works, so it should check that the menu appears visible before clicking through
- an "Overall" row appears at the bottom of the Evaluation > Partisan Balance table, just as it does for demographics tables