### PR TITLE
Work in progress: county-level brush test

### DIFF
--- a/src/components/Toolbar/BrushSlider.js
+++ b/src/components/Toolbar/BrushSlider.js
@@ -3,7 +3,7 @@ import { html } from "lit-html";
 export default (radius, onChange, options) => html`
     <div class="ui-option">
         <legend class="ui-label ui-label--row">
-            ${options ? options.title : "Brush Size"}
+            ${(options && options.title) ? options.title : "Brush Size"}
         </legend>
         <div class="slider-container">
             <input

--- a/src/components/Toolbar/BrushTool.js
+++ b/src/components/Toolbar/BrushTool.js
@@ -75,6 +75,9 @@ class BrushToolOptions {
         if (this.brush.radius != value) {
             this.brush.radius = value;
         }
+        if (this.options.county_brush && this.options.county_brush.radius != value) {
+            this.options.county_brush.radius = value;
+        }
     }
     toggleCountyBrush() {
         this.brush.county_brush = !this.brush.county_brush;
@@ -101,7 +104,7 @@ class BrushToolOptions {
             ${this.colors.length > 1
                 ? BrushColorPicker(this.colors, this.selectColor, activeColor)
                 : ""}
-            ${BrushSlider(this.brush.radius, this.changeRadius, this.options)}
+            ${BrushSlider(this.brush.radius, this.changeRadius)}
             ${this.options && this.options.county_brush
                 ? CountyBrush(this.brush.county_brush, this.toggleCountyBrush)
                 : ""}

--- a/src/components/Toolbar/BrushTool.js
+++ b/src/components/Toolbar/BrushTool.js
@@ -21,11 +21,11 @@ const icon = (active, colorId, colors) => {
 };
 
 export default class BrushTool extends Tool {
-    constructor(brush, colors) {
+    constructor(brush, colors, options) {
         super("brush", "Paint", icon);
         this.brush = brush;
         this.colors = colors;
-        this.options = new BrushToolOptions(brush, colors);
+        this.options = new BrushToolOptions(brush, colors, options);
 
         hotkeys.filter = ({ target }) => {
             return (!["INPUT", "TEXTAREA"].includes(target.tagName)
@@ -57,17 +57,17 @@ export default class BrushTool extends Tool {
 }
 
 class BrushToolOptions {
-    constructor(brush, colors, renderToolbar) {
+    constructor(brush, colors, options) {
         this.brush = brush;
         this.colors = colors;
-        this.renderToolbar = renderToolbar;
+        this.options = options;
         this.selectColor = this.selectColor.bind(this);
         this.changeRadius = this.changeRadius.bind(this);
+        this.toggleCountyBrush = this.toggleCountyBrush.bind(this);
         this.toggleBrushLock = this.toggleBrushLock.bind(this);
     }
     selectColor(e) {
         this.brush.setColor(e.target.value);
-        this.renderToolbar();
     }
     changeRadius(e) {
         e.stopPropagation();
@@ -75,10 +75,25 @@ class BrushToolOptions {
         if (this.brush.radius != value) {
             this.brush.radius = value;
         }
-        this.renderToolbar();
+    }
+    toggleCountyBrush() {
+        this.brush.county_brush = !this.brush.county_brush;
+        // toggle county-unit hover
+        if (this.brush.county_brush) {
+            this.options.county_brush.activate();
+            this.brush.deactivate("mouseover");
+        } else {
+            this.options.county_brush.deactivate();
+            this.brush.activate("mouseover");
+        }
+        // switches county borders visibility to match checkbox
+        let countyLayer = document.getElementById("countyVisible");
+        if (this.brush.county_brush !== countyLayer.checked) {
+            countyLayer.click();
+        }
     }
     toggleBrushLock() {
-        this.brush.locked = this.brush.locked ? false : true;
+        this.brush.locked = !this.brush.locked;
     }
     render() {
         const activeColor = this.colors[this.brush.color].id;
@@ -86,7 +101,10 @@ class BrushToolOptions {
             ${this.colors.length > 1
                 ? BrushColorPicker(this.colors, this.selectColor, activeColor)
                 : ""}
-            ${BrushSlider(this.brush.radius, this.changeRadius)}
+            ${BrushSlider(this.brush.radius, this.changeRadius, this.options)}
+            ${this.options && this.options.county_brush
+                ? CountyBrush(this.brush.county_brush, this.toggleCountyBrush)
+                : ""}
             ${this.colors.length > 1
                 ? BrushLock(this.brush.locked, this.toggleBrushLock)
                 : ""}
@@ -94,6 +112,21 @@ class BrushToolOptions {
         `;
     }
 }
+
+const CountyBrush = (county_brush, toggle) => html`
+    <div class="ui-option">
+        <label class="toolbar-checkbox">
+            <input
+                type="checkbox"
+                name="county-brush"
+                value="county-brush"
+                ?checked=${county_brush}
+                @change=${toggle}
+            />
+            Paint counties
+        </label>
+    </div>
+`;
 
 const BrushLock = (locked, toggle) => html`
     <div class="ui-option">

--- a/src/map/Brush.js
+++ b/src/map/Brush.js
@@ -100,9 +100,9 @@ export default class Brush extends HoverWithRadius {
                         || idSearch("loc_prec", null, (val) => {
                             // Virginia
                             let name = val.split(" ")[0];
-                            if (name.includes("City")) {
+                            if (val.includes("City")) {
                                 name += " City";
-                            } else if (name.includes("County")) {
+                            } else if (val.includes("County")) {
                                 name += " County";
                             }
                             return name; })

--- a/src/map/Brush.js
+++ b/src/map/Brush.js
@@ -157,6 +157,7 @@ export default class Brush extends HoverWithRadius {
                     color: this.color
                 },
                 filter,
+                this.trackUndo[this.cursorUndo],
                 this.listeners.colorfeature);
             });
         }
@@ -167,8 +168,10 @@ export default class Brush extends HoverWithRadius {
     onClick() {
         this.changedColors = new Set();
         this.colorFeatures();
-        for (let listener of this.listeners.colorop) {
-            listener(false, this.changedColors);
+        if (!this.county_brush) {
+            for (let listener of this.listeners.colorop) {
+                listener(false, this.changedColors);
+            }
         }
     }
     onMouseDown(e) {

--- a/src/map/Brush.js
+++ b/src/map/Brush.js
@@ -94,7 +94,9 @@ export default class Brush extends HoverWithRadius {
                         };
                     [countyProp, countyFIPS] = idSearch("GEOID10", 5)
                         || idSearch("VTD", 5)
-                        || idSearch("CNTYVTD", 3)
+                        // || idSearch("CNTYVTD", 3)
+                        // || idSearch("DsslvID", 2) // Utah
+                        // || idSearch("PRECODE", 2) // Oklahoma
                         || idSearch("NAME", null, nameSplice)
                         || idSearch("NAME10", null, nameSplice)
                         || idSearch("loc_prec", null, (val) => {

--- a/src/map/Hover.js
+++ b/src/map/Hover.js
@@ -3,6 +3,7 @@ export class Hover {
         this.layer = layer;
 
         this.hoveredFeature = null;
+        this.deactivatedHover = false;
 
         this.onMouseMove = this.onMouseMove.bind(this);
         this.onMouseLeave = this.onMouseLeave.bind(this);
@@ -19,10 +20,12 @@ export class Hover {
     }
     hoverOn(feature) {
         this.hoveredFeature = feature;
-        this.layer.setFeatureState(feature.id, {
-            ...feature.state,
-            hover: true
-        });
+        if (!this.deactivatedHover) {
+            this.layer.setFeatureState(feature.id, {
+                ...feature.state,
+                hover: true
+            });
+        }
     }
     onMouseMove(e) {
         if (e.features.length > 0) {
@@ -33,13 +36,21 @@ export class Hover {
     onMouseLeave() {
         this.hoverOff();
     }
-    activate() {
+    activate(mouseover) {
+        if (mouseover) {
+            this.deactivatedHover = false;
+            return;
+        }
         this.layer.on("mousemove", this.onMouseMove);
         this.layer.on("mouseleave", this.onMouseLeave);
         this.layer.on("touchmove", this.onMouseMove);
         this.layer.on("touchend", this.onMouseLeave);
     }
-    deactivate() {
+    deactivate(mouseover) {
+        if (mouseover) {
+            this.deactivatedHover = true;
+            return;
+        }
         this.layer.off("mousemove", this.onMouseMove);
         this.layer.off("mouseleave", this.onMouseLeave);
         this.layer.off("touchmove", this.onMouseMove);
@@ -65,12 +76,14 @@ export class HoverWithRadius extends Hover {
     }
     hoverOn(features) {
         this.hoveredFeatures = features;
-        this.hoveredFeatures.forEach(feature => {
-            this.layer.setFeatureState(feature.id, {
-                ...feature.state,
-                hover: true
+        if (!this.deactivatedHover) {
+            this.hoveredFeatures.forEach(feature => {
+                this.layer.setFeatureState(feature.id, {
+                    ...feature.state,
+                    hover: true
+                });
             });
-        });
+        }
     }
     onMouseMove(e) {
         const box = boxAround(e.point, this.radius);

--- a/src/map/Layer.js
+++ b/src/map/Layer.js
@@ -87,6 +87,31 @@ export default class Layer {
             state
         );
     }
+    setCountyState(fips, countyProp, setState, tallyListeners) {
+        let seenFeatures = new Set();
+        this.map.querySourceFeatures(this.sourceId, {
+            sourceLayer: this.sourceLayer,
+            filter: ["all",
+                ["has", countyProp],
+                [">=", ["get", countyProp], fips],
+                ["<", ["get", countyProp], ((isNaN(fips * 1) || countyProp.toLowerCase().includes("name")) ? fips + "z" : String(Number(fips) + 1))]
+            ]
+        }).forEach(feature => {
+            if (!seenFeatures.has(feature.id)) {
+                seenFeatures.add(feature.id);
+
+                feature.state = this.getFeatureState(feature.id);
+                tallyListeners.forEach((listener) => {
+                    listener(feature, setState.color);
+                });
+                this.setFeatureState(feature.id, {
+                    ...feature.state,
+                    color: setState.color
+                });
+                feature.state.color = setState.color;
+            }
+        });
+    }
     setPaintProperty(name, value) {
         this.map.setPaintProperty(this.id, name, value);
     }

--- a/src/map/Layer.js
+++ b/src/map/Layer.js
@@ -87,7 +87,7 @@ export default class Layer {
             state
         );
     }
-    setCountyState(fips, countyProp, setState, filter, tallyListeners) {
+    setCountyState(fips, countyProp, setState, filter, undoInfo, tallyListeners) {
         let seenFeatures = new Set();
         this.map.querySourceFeatures(this.sourceId, {
             sourceLayer: this.sourceLayer,
@@ -101,6 +101,10 @@ export default class Layer {
                 seenFeatures.add(feature.id);
                 feature.state = this.getFeatureState(feature.id);
                 if (filter(feature)) {
+                    undoInfo[feature.id] = {
+                        properties: feature.properties,
+                        color: String(feature.state.color)
+                    };
                     tallyListeners.forEach((listener) => {
                         listener(feature, setState.color);
                     });

--- a/src/map/Layer.js
+++ b/src/map/Layer.js
@@ -87,7 +87,7 @@ export default class Layer {
             state
         );
     }
-    setCountyState(fips, countyProp, setState, tallyListeners) {
+    setCountyState(fips, countyProp, setState, filter, tallyListeners) {
         let seenFeatures = new Set();
         this.map.querySourceFeatures(this.sourceId, {
             sourceLayer: this.sourceLayer,
@@ -99,16 +99,17 @@ export default class Layer {
         }).forEach(feature => {
             if (!seenFeatures.has(feature.id)) {
                 seenFeatures.add(feature.id);
-
                 feature.state = this.getFeatureState(feature.id);
-                tallyListeners.forEach((listener) => {
-                    listener(feature, setState.color);
-                });
-                this.setFeatureState(feature.id, {
-                    ...feature.state,
-                    color: setState.color
-                });
-                feature.state.color = setState.color;
+                if (filter(feature)) {
+                    tallyListeners.forEach((listener) => {
+                        listener(feature, setState.color);
+                    });
+                    this.setFeatureState(feature.id, {
+                        ...feature.state,
+                        color: setState.color
+                    });
+                    feature.state.color = setState.color;
+                }
             }
         });
     }

--- a/src/map/NumberMarkers.js
+++ b/src/map/NumberMarkers.js
@@ -1,4 +1,5 @@
 import Layer from "./Layer";
+import { spatial_abilities } from "../utils";
 
 export default function NumberMarkers(state, brush) {
     state.numbers = [];
@@ -10,7 +11,7 @@ export default function NumberMarkers(state, brush) {
         console.log("not numbering on community of interest");
         return;
     }
-    if (!["alaska", "chicago", "colorado", "georgia", "hawaii", "iowa", "ma", "maryland", "minnesota", "mississippi", "nc", "new_mexico", "oklahoma", "oregon", "pennsylvania", "rhode_island", "texas", "utah", "vermont", "virginia", "wisconsin"].includes(state.place.id)) {
+    if (!spatial_abilities(state.place.id).number_markers) {
         console.log("not on NumberMarkers whitelist");
         return;
     }

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -1,7 +1,7 @@
 import mapboxgl from "mapbox-gl";
 import { unitBordersPaintProperty, getUnitColorProperty } from "../colors";
 import Layer from "./Layer";
-import { stateNameToFips, COUNTIES_TILESET } from "../plugins/data-layers-plugin";
+import { stateNameToFips, COUNTIES_TILESET } from "../utils";
 
 mapboxgl.accessToken =
     "pk.eyJ1IjoiZGlzdHJpY3RyIiwiYSI6ImNqbjUzMTE5ZTBmcXgzcG81ZHBwMnFsOXYifQ.8HRRLKHEJA0AismGk2SX2g";

--- a/src/map/index.js
+++ b/src/map/index.js
@@ -1,6 +1,7 @@
 import mapboxgl from "mapbox-gl";
 import { unitBordersPaintProperty, getUnitColorProperty } from "../colors";
 import Layer from "./Layer";
+import { stateNameToFips, COUNTIES_TILESET } from "../plugins/data-layers-plugin";
 
 mapboxgl.accessToken =
     "pk.eyJ1IjoiZGlzdHJpY3RyIiwiYSI6ImNqbjUzMTE5ZTBmcXgzcG81ZHBwMnFsOXYifQ.8HRRLKHEJA0AismGk2SX2g";
@@ -68,6 +69,31 @@ function addPoints(map, tileset) {
     });
 }
 
+function addCounties(map, tileset, layerAdder, placeID) {
+    map.addSource(tileset.sourceLayer, tileset.source);
+    return new Layer(map, {
+        id: "county-hover",
+        type: "fill",
+        source: tileset.sourceLayer,
+        "source-layer": tileset.sourceLayer,
+        paint: {
+            "fill-opacity": [
+                "case",
+                ["boolean", ["feature-state", "hover"], false],
+                0.6,
+                0
+            ],
+            "fill-color": "#aaa"
+        },
+        filter: [
+            "==",
+            ["get", "STATEFP"],
+            String(stateNameToFips[placeID.toLowerCase()])
+        ]
+    },
+    layerAdder);
+}
+
 export function addLayers(map, parts, tilesets, layerAdder, borderId) {
     for (let tileset of tilesets) {
         map.addSource(tileset.sourceLayer, tileset.source);
@@ -83,6 +109,12 @@ export function addLayers(map, parts, tilesets, layerAdder, borderId) {
         map,
         tilesets.find(tileset => tileset.type === "circle"),
         layerAdder
+    );
+    const counties = addCounties(
+        map,
+        COUNTIES_TILESET,
+        layerAdder,
+        borderId
     );
 
     // cities in Communities of Interest will have a thick border
@@ -112,5 +144,5 @@ export function addLayers(map, parts, tilesets, layerAdder, borderId) {
         });
     }
 
-    return { units, unitsBorders, points };
+    return { units, unitsBorders, points, counties };
 }

--- a/src/models/State.js
+++ b/src/models/State.js
@@ -112,7 +112,7 @@ export default class State {
         return this.plan.parts.filter(part => part.visible);
     }
     initializeMapState(map, unitsRecord, layerAdder, borderId) {
-        const { units, unitsBorders, points } = addLayers(
+        const { units, unitsBorders, points, counties } = addLayers(
             map,
             this.parts,
             unitsRecord.tilesets,
@@ -122,6 +122,7 @@ export default class State {
 
         this.units = units;
         this.unitsBorders = unitsBorders;
+        this.counties = counties;
         this.layers = [units, points];
         this.map = map;
     }

--- a/src/plugins/data-layers-plugin.js
+++ b/src/plugins/data-layers-plugin.js
@@ -4,11 +4,7 @@ import OverlayContainer from "../layers/OverlayContainer";
 import PartisanOverlayContainer from "../layers/PartisanOverlayContainer";
 import LayerTab from "../components/LayerTab";
 import Layer, { addBelowLabels } from "../map/Layer";
-
-export const COUNTIES_TILESET = {
-    sourceLayer: "cb_2018_us_county_500k-6p4p3f",
-    source: { type: "vector", url: "mapbox://districtr.6fcd9f0h" }
-};
+import { stateNameToFips, COUNTIES_TILESET, spatial_abilities } from "../utils";
 
 const COUNTIES_LAYER = {
     id: "counties",
@@ -35,31 +31,31 @@ const COUNTIES_LAYER = {
 };
 
 export function addCountyLayer(tab, state) {
-    // let startFill = window.location.search.includes("county=true") ? 0.4 : 0;
-    // state.map.addSource(COUNTIES_TILESET.sourceLayer, COUNTIES_TILESET.source);
-    // const counties = new Layer(
-    //     state.map,
-    //     {
-    //         ...COUNTIES_LAYER,
-    //         paint: { ...COUNTIES_LAYER.paint, "line-opacity": startFill },
-    //         filter: [
-    //             "==",
-    //             ["get", "STATEFP"],
-    //             String(stateNameToFips[(state.place.state || state.place.id).toLowerCase()])
-    //         ]
-    //     },
-    //     addBelowLabels
-    // );
-    // tab.addSection(
-    //     () => html`
-    //         <h4>Counties</h4>
-    //         ${toggle(`Show county boundaries`, false, checked =>
-    //             counties.setOpacity(
-    //                 checked ? COUNTIES_LAYER.paint["fill-opacity"] : 0
-    //             )
-    //         )}
-    //     `
-    // );
+    let startFill = window.location.search.includes("county=true") ? 0.4 : 0;
+    const counties = new Layer(
+        state.map,
+        {
+            ...COUNTIES_LAYER,
+            paint: { ...COUNTIES_LAYER.paint, "line-opacity": startFill },
+            filter: [
+                "==",
+                ["get", "STATEFP"],
+                String(stateNameToFips[(state.place.state || state.place.id).toLowerCase()])
+            ]
+        },
+        addBelowLabels
+    );
+    tab.addSection(
+        () => html`
+            <h4>Counties</h4>
+            ${toggle(`Show county boundaries`, false, checked =>
+                counties.setOpacity(
+                    checked ? COUNTIES_LAYER.paint["fill-opacity"] : 0
+                ),
+                "countyVisible"
+            )}
+        `
+    );
 }
 
 const amin_type = (window.location.search.split("amin=")[1] || "").split("&")[0] || "shades";
@@ -283,7 +279,7 @@ export default function DataLayersPlugin(editor) {
             })}
             ${(state.plan.problem.type === "community"
               || ["chicago_community_areas"].includes(state.units.sourceId)
-              || !["alaska", "chicago", "colorado", "georgia", "hawaii", "iowa", "ma", "maryland", "minnesota", "mississippi", "nc", "new_mexico", "oklahoma", "oregon", "pennsylvania", "rhode_island", "texas", "utah", "vermont", "virginia", "wisconsin"].includes(state.place.id)
+              || !spatial_abilities(state.place.id).number_markers
             ) ? null
                 : toggle("Show district numbers", false, checked => {
                     let opacity = checked ? 1 : 0;
@@ -298,15 +294,7 @@ export default function DataLayersPlugin(editor) {
         addCountyLayer(tab, state);
     }
 
-    if (["alaska", "hawaii", "new_mexico", "oklahoma",
-        // "california", "ma", "washington", "oregon",
-        // "arizona", "colorado", "connecticut",
-        // "delaware", "florida", "idaho", "iowa", "kansas", "louisiana",
-        // "maine", "michigan", "minnesota", "mississippi", "montana", "nc",
-        // "nebraska", "nevada", "newjersey",  "newyork", "northdakota",
-        // "rhode_island", "southcarolina", "southdakota",
-        // "texas", "utah", "virginia", "wisconsin", "wyoming"
-    ].includes(state.place.id)) {
+    if (spatial_abilities(state.place.id).native_american) {
         addAmerIndianLayer(tab, state);
     }
 
@@ -362,72 +350,3 @@ export default function DataLayersPlugin(editor) {
 
     toolbar.addTab(tab);
 }
-
-export const stateNameToFips = {
-    alabama: "01",
-    alaska: "02",
-    arizona: "04",
-    arkansas: "05",
-    california: "06",
-    colorado: "08",
-    connecticut: "09",
-    delaware: 10,
-    "district of columbia": 11,
-    district_of_columbia: 11,
-    florida: 12,
-    georgia: 13,
-    hawaii: 15,
-    idaho: 16,
-    illinois: 17,
-    indiana: 18,
-    iowa: 19,
-    kansas: 20,
-    kentucky: 21,
-    louisiana: 22,
-    maine: 23,
-    maryland: 24,
-    massachusetts: 25,
-    ma: 25,
-    michigan: 26,
-    minnesota: 27,
-    mississippi: 28,
-    missouri: 29,
-    montana: 30,
-    nebraska: 31,
-    nevada: 32,
-    "new hampshire": 33,
-    new_hampshire: 33,
-    "new jersey": 34,
-    new_jersey: 34,
-    "new mexico": 35,
-    new_mexico: 35,
-    "new york": 36,
-    new_york: 36,
-    "north carolina": 37,
-    north_carolina: 37,
-    nc: 37,
-    "north dakota": 38,
-    north_dakota: 38,
-    ohio: 39,
-    oklahoma: 40,
-    oregon: 41,
-    pennsylvania: 42,
-    "rhode island": 44,
-    rhode_island: 44,
-    "south carolina": 45,
-    south_carolina: 45,
-    "south dakota": 46,
-    south_dakota: 46,
-    tennessee: 47,
-    texas: 48,
-    utah: 49,
-    vermont: 50,
-    virginia: 51,
-    washington: 53,
-    "west virginia": 54,
-    west_virginia: 54,
-    wisconsin: 55,
-    wyoming: 56,
-    "puerto rico": 72,
-    puerto_rico: 72
-};

--- a/src/plugins/data-layers-plugin.js
+++ b/src/plugins/data-layers-plugin.js
@@ -5,7 +5,7 @@ import PartisanOverlayContainer from "../layers/PartisanOverlayContainer";
 import LayerTab from "../components/LayerTab";
 import Layer, { addBelowLabels } from "../map/Layer";
 
-const COUNTIES_TILESET = {
+export const COUNTIES_TILESET = {
     sourceLayer: "cb_2018_us_county_500k-6p4p3f",
     source: { type: "vector", url: "mapbox://districtr.6fcd9f0h" }
 };
@@ -35,31 +35,31 @@ const COUNTIES_LAYER = {
 };
 
 export function addCountyLayer(tab, state) {
-    let startFill = window.location.search.includes("county=true") ? 0.4 : 0;
-    state.map.addSource(COUNTIES_TILESET.sourceLayer, COUNTIES_TILESET.source);
-    const counties = new Layer(
-        state.map,
-        {
-            ...COUNTIES_LAYER,
-            paint: { ...COUNTIES_LAYER.paint, "line-opacity": startFill },
-            filter: [
-                "==",
-                ["get", "STATEFP"],
-                String(stateNameToFips[(state.place.state || state.place.id).toLowerCase()])
-            ]
-        },
-        addBelowLabels
-    );
-    tab.addSection(
-        () => html`
-            <h4>Counties</h4>
-            ${toggle(`Show county boundaries`, false, checked =>
-                counties.setOpacity(
-                    checked ? COUNTIES_LAYER.paint["fill-opacity"] : 0
-                )
-            )}
-        `
-    );
+    // let startFill = window.location.search.includes("county=true") ? 0.4 : 0;
+    // state.map.addSource(COUNTIES_TILESET.sourceLayer, COUNTIES_TILESET.source);
+    // const counties = new Layer(
+    //     state.map,
+    //     {
+    //         ...COUNTIES_LAYER,
+    //         paint: { ...COUNTIES_LAYER.paint, "line-opacity": startFill },
+    //         filter: [
+    //             "==",
+    //             ["get", "STATEFP"],
+    //             String(stateNameToFips[(state.place.state || state.place.id).toLowerCase()])
+    //         ]
+    //     },
+    //     addBelowLabels
+    // );
+    // tab.addSection(
+    //     () => html`
+    //         <h4>Counties</h4>
+    //         ${toggle(`Show county boundaries`, false, checked =>
+    //             counties.setOpacity(
+    //                 checked ? COUNTIES_LAYER.paint["fill-opacity"] : 0
+    //             )
+    //         )}
+    //     `
+    // );
 }
 
 const amin_type = (window.location.search.split("amin=")[1] || "").split("&")[0] || "shades";
@@ -363,7 +363,7 @@ export default function DataLayersPlugin(editor) {
     toolbar.addTab(tab);
 }
 
-const stateNameToFips = {
+export const stateNameToFips = {
     alabama: "01",
     alaska: "02",
     arizona: "04",

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -9,7 +9,7 @@ import NumberMarkers from "../map/NumberMarkers";
 import ContiguityChecker from "../map/contiguity";
 import { renderAboutModal, renderSaveModal } from "../components/Modal";
 import { navigateTo, savePlanToStorage, savePlanToDB } from "../routes";
-import { download } from "../utils";
+import { download, spatial_abilities /* , stateNameToFips */ } from "../utils";
 
 export default function ToolsPlugin(editor) {
     const { state, toolbar } = editor;
@@ -17,9 +17,11 @@ export default function ToolsPlugin(editor) {
     brush.on("colorfeature", state.update);
     brush.on("colorend", state.render);
     brush.on("colorend", toolbar.unsave);
-    
-    const countyHover = new HoverWithRadius(state.counties, 20);
-    countyHover.activate();
+
+    let brushOptions = {};
+    if (spatial_abilities(state.place.id).county_brush) {
+        brushOptions.county_brush = new HoverWithRadius(state.counties, 20);
+    }
 
     let planNumbers = NumberMarkers(state, brush);
     const c_checker = ContiguityChecker(state, brush);
@@ -35,7 +37,7 @@ export default function ToolsPlugin(editor) {
 
     let tools = [
         new PanTool(),
-        new BrushTool(brush, state.parts),
+        new BrushTool(brush, state.parts, brushOptions),
         new EraserTool(brush),
         (state.problem.type === "community" && new LandmarkTool(state)),
         new InspectTool(

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -4,6 +4,7 @@ import InspectTool from "../components/Toolbar/InspectTool";
 import PanTool from "../components/Toolbar/PanTool";
 import LandmarkTool from "../components/Toolbar/LandmarkTool";
 import Brush from "../map/Brush";
+import { HoverWithRadius } from "../map/Hover";
 import NumberMarkers from "../map/NumberMarkers";
 import ContiguityChecker from "../map/contiguity";
 import { renderAboutModal, renderSaveModal } from "../components/Modal";
@@ -16,6 +17,9 @@ export default function ToolsPlugin(editor) {
     brush.on("colorfeature", state.update);
     brush.on("colorend", state.render);
     brush.on("colorend", toolbar.unsave);
+    
+    const countyHover = new HoverWithRadius(state.counties, 20);
+    countyHover.activate();
 
     let planNumbers = NumberMarkers(state, brush);
     const c_checker = ContiguityChecker(state, brush);

--- a/src/utils.js
+++ b/src/utils.js
@@ -157,3 +157,171 @@ export function bindAll(keys, obj) {
         obj[key] = obj[key].bind(obj);
     });
 }
+
+export const COUNTIES_TILESET = {
+    sourceLayer: "cb_2018_us_county_500k-6p4p3f",
+    source: { type: "vector", url: "mapbox://districtr.6fcd9f0h" }
+};
+
+export const stateNameToFips = {
+    alabama: "01",
+    alaska: "02",
+    arizona: "04",
+    arkansas: "05",
+    california: "06",
+    colorado: "08",
+    connecticut: "09",
+    delaware: 10,
+    "district of columbia": 11,
+    district_of_columbia: 11,
+    florida: 12,
+    georgia: 13,
+    hawaii: 15,
+    idaho: 16,
+    illinois: 17,
+    indiana: 18,
+    iowa: 19,
+    kansas: 20,
+    kentucky: 21,
+    louisiana: 22,
+    maine: 23,
+    maryland: 24,
+    massachusetts: 25,
+    ma: 25,
+    michigan: 26,
+    minnesota: 27,
+    mississippi: 28,
+    missouri: 29,
+    montana: 30,
+    nebraska: 31,
+    nevada: 32,
+    "new hampshire": 33,
+    new_hampshire: 33,
+    "new jersey": 34,
+    new_jersey: 34,
+    "new mexico": 35,
+    new_mexico: 35,
+    "new york": 36,
+    new_york: 36,
+    "north carolina": 37,
+    north_carolina: 37,
+    nc: 37,
+    "north dakota": 38,
+    north_dakota: 38,
+    ohio: 39,
+    oklahoma: 40,
+    oregon: 41,
+    pennsylvania: 42,
+    "rhode island": 44,
+    rhode_island: 44,
+    "south carolina": 45,
+    south_carolina: 45,
+    "south dakota": 46,
+    south_dakota: 46,
+    tennessee: 47,
+    texas: 48,
+    utah: 49,
+    vermont: 50,
+    virginia: 51,
+    washington: 53,
+    "west virginia": 54,
+    west_virginia: 54,
+    wisconsin: 55,
+    wyoming: 56,
+    "puerto rico": 72,
+    puerto_rico: 72
+};
+
+export function spatial_abilities (id) {
+  const status = {
+      alaska: {
+        number_markers: true,
+        // precincts cross county lines
+        native_american: true,
+      },
+      chicago: {
+        number_markers: true,
+      },
+      colorado: {
+        number_markers: true,
+        county_brush: true,
+      },
+      georgia: {
+        number_markers: true,
+      },
+      hawaii: {
+        number_markers: true,
+        native_american: true,
+      },
+      iowa: {
+        number_markers: true,
+      },
+      maryland: {
+        number_markers: true,
+        county_brush: true,
+      },
+      ma: {
+        number_markers: true,
+        // modern precincts, towns have issues
+      },
+      michigan: {
+        number_markers: true,
+        // precode?
+      },
+      minnesota: {
+        number_markers: true,
+        county_brush: true,
+      },
+      mississippi: {
+        number_markers: true,
+        county_brush: true,
+      },
+      new_mexico: {
+        number_markers: true,
+        county_brush: true,
+        native_american: true,
+      },
+      nc: {
+        number_markers: true,
+        county_brush: true,
+      },
+      ohio: {
+        number_markers: true,
+      },
+      oklahoma: {
+        number_markers: true,
+        native_american: true,
+      },
+      oregon: {
+        number_markers: true,
+        county_brush: true,
+      },
+      pennsylvania: {
+        number_markers: true,
+        county_brush: true,
+      },
+      rhode_island: {
+        number_markers: true,
+      },
+      texas: {
+        number_markers: true,
+        county_brush: true,
+      },
+      utah: {
+        number_markers: true,
+      },
+      vermont: {
+        number_markers: true,
+        county_brush: true,
+      },
+      virginia: {
+        number_markers: true,
+        county_brush: true,
+      },
+      wisconsin: {
+        number_markers: true,
+        county_brush: true,
+      },
+  };
+  return status[id] || {};
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -316,7 +316,6 @@ export function spatial_abilities (id) {
       },
       virginia: {
         number_markers: true,
-        county_brush: true,
       },
       wisconsin: {
         number_markers: true,

--- a/src/utils.js
+++ b/src/utils.js
@@ -305,7 +305,6 @@ export function spatial_abilities (id) {
       },
       texas: {
         number_markers: true,
-        county_brush: true,
       },
       utah: {
         number_markers: true,


### PR DESCRIPTION
First draft - for states with a GEOID10 unit identifier (such as Pennsylvania) you paint a full county with one click, and its population gets added to the district.  You can also erase a full county with one click.

UI: still TBD