### PR TITLE
Remove Missouri from available maps

### DIFF
--- a/src/components/PlaceMap.js
+++ b/src/components/PlaceMap.js
@@ -21,7 +21,7 @@ const available = [
     "Michigan",
     "Minnesota",
     "Iowa",
-    "Missouri",
+    // "Missouri",
     "Mississippi",
     "Illinois",
     "Texas",


### PR DESCRIPTION
Following recommendation today, remove Missouri from the national maps on /new and /community

Saved maps will continue to work and be editable