### PR TITLE
Quick fix: bar chart labels in super-overpopulated districts

### DIFF
--- a/src/components/Charts/PopulationBarChart.js
+++ b/src/components/Charts/PopulationBarChart.js
@@ -64,12 +64,14 @@ const horizontalBarChart = (population, parts) => {
                 : ""
         }
     ${data.map((d, i) => {
-        const barW = barLength(d, maxValue);
+        let barW = barLength(d, maxValue),
+              textX = barW + 2 * gap;
         return Math.round(d) > 0
             ? svg`
     <text
-        style="font-size: ${textHeight}px"
-        x="${barW + 2 * gap}"
+        style="font-size: ${textHeight}px;${(textX <= 240) || ('font-weight:bold;fill:#f00;')}"
+        x="${(textX > 240) ? 300 : textX}"
+        text-anchor="${(textX > 240) ? 'end' : 'start'}"
         y="${i * (w + gap) +
             w -
             (w + gap - textHeight) / 2}">${numberWithCommas(


### PR DESCRIPTION
When population of a district is much higher than the ideal (roughly 1.75-2x the ideal), the label currently gets pushed behind the right edge of the bar chart.
This PR brings the text inside the edge of the chart and colors it red.

## Before:
![Screen Shot 2020-01-13 at 12 15 28 PM](https://user-images.githubusercontent.com/643918/72276637-6921a780-35fe-11ea-8556-6a2100924192.png)

## After:
![Screen Shot 2020-01-13 at 12 11 58 PM](https://user-images.githubusercontent.com/643918/72276535-219b1b80-35fe-11ea-91f9-d71afa8073f8.png)
