### PR TITLE
Number districts using PostGIS

### DIFF
--- a/src/components/Toggle.js
+++ b/src/components/Toggle.js
@@ -1,9 +1,10 @@
 import { html } from "lit-html";
 
-export function toggle(label, checked, onChange) {
+export function toggle(label, checked, onChange, optionalId) {
     return html`
         <label class="toolbar-checkbox">
             <input
+                id="${optionalId || null}"
                 type="checkbox"
                 ?checked="${checked}"
                 @change="${e => onChange(e.target.checked)}"

--- a/src/map/Layer.js
+++ b/src/map/Layer.js
@@ -64,7 +64,7 @@ export default class Layer {
         this.getFeature = this.getFeature.bind(this);
     }
     setOpacity(opacity) {
-        this.setPaintProperty(`${this.type}-opacity`, opacity);
+        this.setPaintProperty(`${this.type.replace("symbol", "icon")}-opacity`, opacity);
     }
     setColor(color) {
         this.setPaintProperty(`${this.type}-color`, color);

--- a/src/map/NumberMarkers.js
+++ b/src/map/NumberMarkers.js
@@ -103,7 +103,10 @@ export default function NumberMarkers(state, brush) {
                 }
 
                 fetch(`https://mggg-states.subzero.cloud/rest/rpc/merged_${place}?ids=${markers[district_num].join(",")}`).then(res => res.json()).then((centroid) => {
-                    let latlng = centroid[0][`merged_${place}`].split(" "),
+                    if (typeof centroid === "object") {
+                        centroid = centroid[0][`merged_${place}`];
+                    }
+                    let latlng = centroid.split(" "),
                         lat = latlng[1].split(")")[0] * 1,
                         lng = latlng[0].split("(")[1] * 1;
                     if (numberMarkers[district_num]) {

--- a/src/map/NumberMarkers.js
+++ b/src/map/NumberMarkers.js
@@ -17,25 +17,25 @@ export default function NumberMarkers(state, brush) {
         i = 0,
         districts = [],
         map = state.units.map;
-    canv.height = 30;
+    canv.height = 22;
     while (i < state.problem.numberOfParts) {
         districts.push(i);
         i++;
     }
     districts.forEach((dnum) => {
-        canv.width = 40;
+        canv.width = 32;
         ctx.strokeStyle = "#000";
         ctx.fillStyle = "#fff";
         ctx.lineWidth = 2;
-        ctx.ellipse(20, 15, 16, 12, 0, 0, 2 * Math.PI);
+        ctx.ellipse(16, 11, 14, 10, 0, 0, 2 * Math.PI);
         ctx.fill();
         ctx.stroke();
         ctx.fillStyle = "#000";
-        ctx.font = "16px sans-serif";
+        ctx.font = "14px sans-serif";
         ctx.fillText(
             dnum + 1,
-            20 - ctx.measureText(dnum + 1).width / 2,
-            21
+            16 - ctx.measureText(dnum + 1).width / 2,
+            16
         );
         // if (!dnum) {
         //     console.log(canv.toDataURL());

--- a/src/map/NumberMarkers.js
+++ b/src/map/NumberMarkers.js
@@ -1,8 +1,13 @@
 import Layer from "./Layer";
 
 export default function NumberMarkers(state, brush) {
+    state.numbers = [];
     if (!state.problem || !state.problem.numberOfParts) {
         console.log("no numberOfParts for NumberMarkers");
+        return;
+    }
+    if (state.plan.problem.type === "community") {
+        console.log("not numbering on community of interest");
         return;
     }
 
@@ -45,23 +50,21 @@ export default function NumberMarkers(state, brush) {
                 throw err;
             }
             map.addImage("number_icon_" + dnum, numberimg);
-            new Layer(
+            state.numbers.push(new Layer(
                 map,
                 {
                     id: "number_layer_" + dnum,
                     source: "number_source_" + dnum,
-                    type: "symbol", // circle
-                    // paint: {
-                    //     'circle-opacity': 1,
-                    //     'circle-radius': 8,
-                    //     'circle-color': '#f00'
-                    // }
+                    type: "symbol",
+                    paint: {
+                        "icon-opacity": 1
+                    },
                     layout: {
                         "icon-image": "number_icon_" + dnum,
                         "icon-size": 1
                     }
                 }
-            );
+            ));
         });
     });
 

--- a/src/map/NumberMarkers.js
+++ b/src/map/NumberMarkers.js
@@ -70,7 +70,9 @@ export default function NumberMarkers(state, brush) {
 
     const updater = (state, colorsAffected) => {
         let plan = state.plan,
-            place = state.place.id;
+            place = state.place.id,
+            extra_source = (state.units.sourceId === "ma_precincts_02_10") ? "ma_02" : 0,
+            placeID = extra_source || place;
         if (plan && plan.assignment) {
             let markers = {},
                 seenDistricts = new Set();
@@ -102,9 +104,9 @@ export default function NumberMarkers(state, brush) {
                     markers[district_num] = markers[district_num].filter(() => (Math.random() < filterOdds));
                 }
 
-                fetch(`https://mggg-states.subzero.cloud/rest/rpc/merged_${place}?ids=${markers[district_num].join(",")}`).then(res => res.json()).then((centroid) => {
+                fetch(`https://mggg-states.subzero.cloud/rest/rpc/merged_${placeID}?ids=${markers[district_num].join(",")}`).then(res => res.json()).then((centroid) => {
                     if (typeof centroid === "object") {
-                        centroid = centroid[0][`merged_${place}`];
+                        centroid = centroid[0][`merged_${placeID}`];
                     }
                     let latlng = centroid.split(" "),
                         lat = latlng[1].split(")")[0] * 1,

--- a/src/map/NumberMarkers.js
+++ b/src/map/NumberMarkers.js
@@ -23,18 +23,18 @@ export default function NumberMarkers(state, brush) {
         i++;
     }
     districts.forEach((dnum) => {
-        canv.width = 30;
+        canv.width = 40;
         ctx.strokeStyle = "#000";
         ctx.fillStyle = "#fff";
         ctx.lineWidth = 2;
-        ctx.arc(15, 15, 12, 0, 2 * Math.PI);
+        ctx.ellipse(20, 15, 16, 12, 0, 0, 2 * Math.PI);
         ctx.fill();
         ctx.stroke();
         ctx.fillStyle = "#000";
         ctx.font = "16px sans-serif";
         ctx.fillText(
             dnum + 1,
-            15 - ctx.measureText(dnum + 1).width / 2,
+            20 - ctx.measureText(dnum + 1).width / 2,
             21
         );
         // if (!dnum) {

--- a/src/plugins/data-layers-plugin.js
+++ b/src/plugins/data-layers-plugin.js
@@ -80,7 +80,7 @@ export default function DataLayersPlugin(editor) {
             })}
             ${(state.plan.problem.type === "community"
                 || ["santa_clara", "lowell", "little_rock", "austin", "islip"].includes(state.place.id)
-                || ["ma_precincts_02_10", "chicago_community_areas"].includes(state.units.sourceId)) ? null
+                || ["chicago_community_areas"].includes(state.units.sourceId)) ? null
                 : toggle("Show district numbers", true, checked => {
                     let opacity = checked ? 1 : 0;
                     state.numbers.forEach((number) => {

--- a/src/plugins/data-layers-plugin.js
+++ b/src/plugins/data-layers-plugin.js
@@ -78,8 +78,9 @@ export default function DataLayersPlugin(editor) {
                 let opacity = checked ? 0.8 : 0;
                 state.units.setOpacity(opacity);
             })}
-            ${(state.plan.problem.type === "community" ||
-              (["mississippi", "santa_clara", "chicago", "lowell", "little_rock", "austin", "islip", "ma"].includes(state.place.id))) ? null
+            ${(state.plan.problem.type === "community"
+                || ["santa_clara", "lowell", "little_rock", "austin", "islip"].includes(state.place.id)
+                || ["ma_precincts_02_10", "chicago_community_areas"].includes(state.units.sourceId)) ? null
                 : toggle("Show district numbers", true, checked => {
                     let opacity = checked ? 1 : 0;
                     state.numbers.forEach((number) => {

--- a/src/plugins/data-layers-plugin.js
+++ b/src/plugins/data-layers-plugin.js
@@ -75,12 +75,17 @@ export default function DataLayersPlugin(editor) {
         () => html`
             <h4>${districtsHeading}</h4>
             ${toggle(districtMessage, true, checked => {
-                if (checked) {
-                    state.units.setOpacity(0.8);
-                } else {
-                    state.units.setOpacity(0);
-                }
+                let opacity = checked ? 0.8 : 0;
+                state.units.setOpacity(opacity);
             })}
+            ${(state.plan.problem.type === "community" ||
+              (["mississippi", "santa_clara", "chicago", "lowell", "little_rock", "austin", "islip", "ma"].includes(state.place.id))) ? null
+                : toggle("Show district numbers", true, checked => {
+                    let opacity = checked ? 1 : 0;
+                    state.numbers.forEach((number) => {
+                        number.setOpacity(Math.round(opacity))
+                    });
+                }, "toggle-district-numbers")}
         `
     );
 

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -19,7 +19,9 @@ export default function ToolsPlugin(editor) {
     let planNumbers = NumberMarkers(state, brush);
     brush.on("colorop", (isUndoRedo, colorsAffected) => {
         savePlanToStorage(state.serialize());
-        planNumbers.update(state, colorsAffected);
+        if (planNumbers) {
+            planNumbers.update(state, colorsAffected);
+        }
     });
 
     let tools = [

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -4,6 +4,7 @@ import InspectTool from "../components/Toolbar/InspectTool";
 import PanTool from "../components/Toolbar/PanTool";
 import LandmarkTool from "../components/Toolbar/LandmarkTool";
 import Brush from "../map/Brush";
+import NumberMarkers from "../map/NumberMarkers";
 import { renderAboutModal, renderSaveModal } from "../components/Modal";
 import { navigateTo, savePlanToStorage, savePlanToDB } from "../routes";
 import { download } from "../utils";
@@ -14,8 +15,11 @@ export default function ToolsPlugin(editor) {
     brush.on("colorfeature", state.update);
     brush.on("colorend", state.render);
     brush.on("colorend", toolbar.unsave);
-    brush.on("colorop", () => {
+
+    let planNumbers = NumberMarkers(state, brush);
+    brush.on("colorop", (isUndoRedo, colorsAffected) => {
         savePlanToStorage(state.serialize());
+        planNumbers.update(state, colorsAffected);
     });
 
     let tools = [

--- a/src/views/edit.js
+++ b/src/views/edit.js
@@ -162,7 +162,9 @@ function loadContext(context) {
         let state = new State(mapState.map, context, () => {
             window.document.title = "Districtr";
         });
-        state.plan.assignment = context.assignment; // know loaded district assignments
+        if (context.assignment) {
+            state.plan.assignment = context.assignment; // know loaded district assignments
+        }
         let editor = new Editor(state, mapState, getPlugins(context));
         editor.render();
     });

--- a/src/views/edit.js
+++ b/src/views/edit.js
@@ -162,6 +162,7 @@ function loadContext(context) {
         let state = new State(mapState.map, context, () => {
             window.document.title = "Districtr";
         });
+        state.plan.assignment = context.assignment; // know loaded district assignments
         let editor = new Editor(state, mapState, getPlugins(context));
         editor.render();
     });


### PR DESCRIPTION
What if districts had numbers?
This is potentially helpful on maps with 8 or more districts, when it is difficult to tell colors apart

Whenever map updates -> collect unique unit IDs -> limit to 100 units per district -> GET request to PostgREST -> query on PostGIS -> return lng,lat of centroid

![Screen Shot 2020-01-14 at 4 38 03 PM](https://user-images.githubusercontent.com/643918/72384871-4bcb0700-36ec-11ea-9ff4-064b7bedfca9.png)

- Works on almost all maps - not on some cities and MA 2002-2010
- Needs UI to toggle on/off
- Confusing if your district is a multi-polygon, donut-shaped, or earmuffs

**This is a fork of the undo/redo feature branch** - that should be merged first