### PR TITLE
Contiguity checks in Evaluation tab

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-    "presets": ["@babel/preset-env"]
+    "presets": ["@babel/preset-env"],
+    "plugins": ["@babel/plugin-transform-runtime"]
 }

--- a/package.json
+++ b/package.json
@@ -66,10 +66,13 @@
         "webpack-merge": "^4.2.2"
     },
     "dependencies": {
+        "@babel/plugin-transform-runtime": "^7.8.3",
+        "@babel/runtime": "^7.8.3",
         "d3-geo": "^1.11.6",
         "d3-scale-chromatic": "^1.5.0",
         "d3-selection": "^1.4.0",
         "d3-transition": "^1.2.0",
+        "encoding": "^0.1.12",
         "hotkeys-js": "^3.7.3",
         "lit-html": "^1.1.2",
         "mapbox-gl": "^1.3.1"

--- a/sass/components/_icon-list.scss
+++ b/sass/components/_icon-list.scss
@@ -77,6 +77,11 @@ of the whole element */
 
     // background: #111;
     background-color: white;
+
+    border: 1px solid transparent;
+    &.contiguity {
+        border-color: #f00;
+    }
 }
 
 .icon-list__item:hover input ~ .icon-list__item__radio {
@@ -97,6 +102,7 @@ of the whole element */
 .icon-list__item input:checked ~ .icon-list__item__radio {
     border-radius: 50%;
     background-color: $districtr-grey-active;
+    box-shadow: 1px 1px 2px #444;
 }
 
 i {

--- a/sass/components/_icon-list.scss
+++ b/sass/components/_icon-list.scss
@@ -102,7 +102,10 @@ of the whole element */
 .icon-list__item input:checked ~ .icon-list__item__radio {
     border-radius: 50%;
     background-color: $districtr-grey-active;
-    box-shadow: 1px 1px 2px #444;
+
+    .color-list & {
+        box-shadow: 1px 1px 2px #444;
+    }
 }
 
 i {

--- a/sass/components/_toolbar.scss
+++ b/sass/components/_toolbar.scss
@@ -30,6 +30,12 @@
     align-items: center;
 }
 
+.district-row {
+    flex-direction: row;
+    justify-content: flex-start;
+    display: flex;
+}
+
 fieldset {
     margin: 0.5rem 0;
     padding: 0;

--- a/src/components/Charts/ContiguitySection.js
+++ b/src/components/Charts/ContiguitySection.js
@@ -1,5 +1,6 @@
 import { html } from "lit-html";
 import { actions } from "../../reducers/charts";
+import { districtColors } from "../../colors";
 
 export default function ContiguitySection(
     contiguity,
@@ -8,7 +9,21 @@ export default function ContiguitySection(
 ) {
     return html`
         <section class="toolbar-section">
-            ${JSON.stringify(contiguity).split(",").join(", ")}
+            <h4>Districts with contiguity gaps</h4>
+            <div class="district-row">
+                ${Object.keys(contiguity).map((dnum) => {
+                    return html`
+                        <span
+                            id="contiguity-${dnum}"
+                            class="part-number"
+                            style="background:${districtColors[dnum].hex};
+                                  display:${contiguity[dnum] ? "none" : "flex"};"
+                        >
+                            ${Number(dnum) + 1}
+                        </span>
+                    `;
+                })}
+            </div>
         </section>
     `;
 }

--- a/src/components/Charts/ContiguitySection.js
+++ b/src/components/Charts/ContiguitySection.js
@@ -1,12 +1,14 @@
 import { html } from "lit-html";
+import { actions } from "../../reducers/charts";
 
 export default function ContiguitySection(
+    contiguity,
     uiState,
     dispatch
 ) {
     return html`
         <section class="toolbar-section">
-            ${JSON.stringify(window.d_contiguity)}
+            ${JSON.stringify(contiguity).split(",").join(", ")}
         </section>
     `;
 }

--- a/src/components/Charts/ContiguitySection.js
+++ b/src/components/Charts/ContiguitySection.js
@@ -3,21 +3,32 @@ import { actions } from "../../reducers/charts";
 import { districtColors } from "../../colors";
 
 export default function ContiguitySection(
-    contiguity,
+    contiguities,
     uiState,
     dispatch
 ) {
+    let foundDiscontiguity = false;
+    Object.keys(contiguities).forEach((d) => {
+        if (!contiguities[d]) {
+            foundDiscontiguity = true;
+        }
+    });
     return html`
         <section class="toolbar-section">
-            <h4>Districts with contiguity gaps</h4>
+            <h4 id="contiguity-status">
+                ${foundDiscontiguity
+                    ? "Districts with contiguity gaps"
+                    : "Any districts are contiguous"
+                }
+            </h4>
             <div class="district-row">
-                ${Object.keys(contiguity).map((dnum) => {
+                ${Object.keys(contiguities).map((dnum) => {
                     return html`
                         <span
                             id="contiguity-${dnum}"
                             class="part-number"
                             style="background:${districtColors[dnum].hex};
-                                  display:${contiguity[dnum] ? "none" : "flex"};"
+                                  display:${contiguities[dnum] ? "none" : "flex"};"
                         >
                             ${Number(dnum) + 1}
                         </span>

--- a/src/components/Charts/ContiguitySection.js
+++ b/src/components/Charts/ContiguitySection.js
@@ -17,7 +17,7 @@ export default function ContiguitySection(
         <section class="toolbar-section">
             <h4 id="contiguity-status">
                 ${foundDiscontiguity
-                    ? "Districts with contiguity gaps"
+                    ? "Districts may have contiguity gaps"
                     : "Any districts are contiguous"
                 }
             </h4>

--- a/src/components/Charts/ContiguitySection.js
+++ b/src/components/Charts/ContiguitySection.js
@@ -1,0 +1,12 @@
+import { html } from "lit-html";
+
+export default function ContiguitySection(
+    uiState,
+    dispatch
+) {
+    return html`
+        <section class="toolbar-section">
+            ${JSON.stringify(window.d_contiguity)}
+        </section>
+    `;
+}

--- a/src/components/Toolbar/BrushColorPicker.js
+++ b/src/components/Toolbar/BrushColorPicker.js
@@ -43,7 +43,7 @@ export default (colors, onInput, activeColor) => html`
                                 @change="${onInput}"
                             />
                             <div
-                                class="icon-list__item__radio ${window.d_contiguity[color.displayNumber - 1] ? '' : 'contiguity'}"
+                                class="icon-list__item__radio"
                                 style="background: ${color.color}"
                             ></div>
                         </li>

--- a/src/components/Toolbar/BrushColorPicker.js
+++ b/src/components/Toolbar/BrushColorPicker.js
@@ -43,7 +43,7 @@ export default (colors, onInput, activeColor) => html`
                                 @change="${onInput}"
                             />
                             <div
-                                class="icon-list__item__radio"
+                                class="icon-list__item__radio ${window.d_contiguity[color.displayNumber - 1] ? '' : 'contiguity'}"
                                 style="background: ${color.color}"
                             ></div>
                         </li>

--- a/src/lambda/planContiguity.js
+++ b/src/lambda/planContiguity.js
@@ -5,16 +5,21 @@ import fetch from "node-fetch";
 exports.handler = async (event, context) => {
   context.callbackWaitsForEmptyEventLoop = false;
 
+  const eventBody = JSON.parse(event.body);
+
   try {
+      if (!['alaska', 'chicago', 'colorado', 'georgia', 'hawaii', 'iowa', 'ma',
+        'maryland', 'michigan', 'minnesota', 'nc', 'new_mexico', 'ohio', 'oklahoma',
+        'oregon', 'pennsylvania', 'providence_ri', 'rhode_island', 'texas', 'utah',
+        'virginia', 'vermont', 'wisconsin'].includes(eventBody.state)) {
+          throw new Error('State not included in PostGIS, according to planContiguity.js');
+      }
+
       return new Promise((resolve, reject) => {
-          fetch('https://mggg-states.subzero.cloud/rest/rpc/contiguity_pennsylvania', {
+          fetch('https://mggg-states.subzero.cloud/rest/rpc/contiguity_' + eventBody.state, {
               method: 'POST',
-              headers: {
-                  'Content-Type': 'application/json'
-              },
-              body: JSON.stringify({
-                  ids: JSON.parse(event.body).ids
-              })
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ ids: eventBody.ids })
           })
           .then(resp => resp.json())
           .then((data) => {

--- a/src/lambda/planContiguity.js
+++ b/src/lambda/planContiguity.js
@@ -1,0 +1,35 @@
+// planContiguity.js
+import querystring from "querystring";
+import fetch from "node-fetch";
+
+exports.handler = async (event, context) => {
+  context.callbackWaitsForEmptyEventLoop = false;
+
+  try {
+      return new Promise((resolve, reject) => {
+          fetch('https://mggg-states.subzero.cloud/rest/rpc/contiguity_pennsylvania', {
+              method: 'POST',
+              headers: {
+                  'Content-Type': 'application/json'
+              },
+              body: JSON.stringify({
+                  ids: JSON.parse(event.body).ids
+              })
+          })
+          .then(resp => resp.json())
+          .then((data) => {
+              resolve({
+                  statusCode: 200,
+                  body: JSON.stringify(data)
+              });
+          });
+
+      });
+  } catch (err) {
+      console.log(err) // output to netlify function log
+      return {
+          statusCode: 500,
+          body: JSON.stringify({msg: err.message})
+      }
+  }
+};

--- a/src/lambda/planContiguity.js
+++ b/src/lambda/planContiguity.js
@@ -9,9 +9,10 @@ exports.handler = async (event, context) => {
 
   try {
       if (!['alaska', 'chicago', 'colorado', 'georgia', 'hawaii', 'iowa', 'ma',
-        'maryland', 'michigan', 'minnesota', 'nc', 'new_mexico', 'ohio', 'oklahoma',
-        'oregon', 'pennsylvania', 'providence_ri', 'rhode_island', 'texas', 'utah',
-        'virginia', 'vermont', 'wisconsin'].includes(eventBody.state)) {
+        'ma_02', 'maryland', 'michigan', 'minnesota', 'mississippi', 'nc',
+        'new_mexico', 'ohio', 'oklahoma', 'oregon', 'pennsylvania',
+        'providence_ri', 'rhode_island', 'texas', 'utah', 'virginia',
+        'vermont', 'wisconsin'].includes(eventBody.state)) {
           throw new Error('State not included in PostGIS, according to planContiguity.js');
       }
 

--- a/src/map/Brush.js
+++ b/src/map/Brush.js
@@ -126,7 +126,7 @@ export default class Brush extends HoverWithRadius {
         }
 
         // limit number of changes in the stack
-        if (this.trackUndo.length > 19) {
+        if (this.trackUndo.length > 9) {
             this.trackUndo = this.trackUndo.slice(1);
         }
 

--- a/src/map/contiguity.js
+++ b/src/map/contiguity.js
@@ -5,7 +5,8 @@ export default function ContiguityChecker(state, brush) {
 
     const updater = (state, colorsAffected) => {
         let assignment = state.plan.assignment,
-            place = state.place.id,
+            source = (state.units.sourceId === "ma_precincts_02_10") ? "ma_02" : 0,
+            place = source || state.place.id,
             testIDs = {};
 
         Object.keys(assignment).forEach((unit_id) => {

--- a/src/map/contiguity.js
+++ b/src/map/contiguity.js
@@ -1,7 +1,9 @@
 
 export default function ContiguityChecker(state, brush) {
     const host = (window.location.hostname === "localhost") ? "https://deploy-preview-157--districtr-web.netlify.com" : "";
-    window.d_contiguity = {};
+    if (!state.contiguity) {
+        state.contiguity = {};
+    }
 
     const updater = (state, colorsAffected) => {
         let assignment = state.plan.assignment,
@@ -26,7 +28,7 @@ export default function ContiguityChecker(state, brush) {
             }
             if (!testIDs[dnum] || testIDs[dnum].length <= 1) {
                 // 0-1 precincts automatically OK
-                window.d_contiguity[dnum] = true;
+                state.contiguity[dnum] = true;
                 // try {
                 //     document.querySelector(`.color-list li[title='${dnum + 1}'] div`).className = "icon-list__item__radio";
                 // } catch(e) {
@@ -52,7 +54,7 @@ export default function ContiguityChecker(state, brush) {
                 }
                 let keys = Object.keys(data),
                     geomType = data[keys[0]];
-                window.d_contiguity[dnum] = (geomType !== "ST_MultiPolygon");
+                state.contiguity[dnum] = (geomType !== "ST_MultiPolygon");
                 // try {
                 //     document.querySelector(".color-list li[title='" + (dnum + 1) + "'] div").className =
                 //         "icon-list__item__radio " + (window.d_contiguity[dnum] ? "" : "contiguity");

--- a/src/map/contiguity.js
+++ b/src/map/contiguity.js
@@ -12,7 +12,7 @@ function setContiguityStatus(contiguities, dnum) {
         });
         document.querySelector("#contiguity-status").innerText =
             foundDiscontiguity
-                ? "Districts with contiguity gaps"
+                ? "Districts may have contiguity gaps"
                 : "Any districts are contiguous"
     } catch(e) { }
 }

--- a/src/map/contiguity.js
+++ b/src/map/contiguity.js
@@ -63,7 +63,9 @@ export default function ContiguityChecker(state, brush) {
             })
             .then(res => res.json())
             .then((data) => {
-                if (data.length) {
+                if (typeof data === "string") {
+                    data = { "response": data };
+                } else if (data.length) {
                     data = data[0];
                 }
                 let keys = Object.keys(data),

--- a/src/map/contiguity.js
+++ b/src/map/contiguity.js
@@ -27,10 +27,10 @@ export default function ContiguityChecker(state, brush) {
             if (!testIDs[dnum] || testIDs[dnum].length <= 1) {
                 // 0-1 precincts automatically OK
                 window.d_contiguity[dnum] = true;
-                try {
-                    document.querySelector(`.color-list li[title='${dnum + 1}'] div`).className = "icon-list__item__radio";
-                } catch(e) {
-                }
+                // try {
+                //     document.querySelector(`.color-list li[title='${dnum + 1}'] div`).className = "icon-list__item__radio";
+                // } catch(e) {
+                // }
                 return;
             }
 
@@ -53,12 +53,11 @@ export default function ContiguityChecker(state, brush) {
                 let keys = Object.keys(data),
                     geomType = data[keys[0]];
                 window.d_contiguity[dnum] = (geomType !== "ST_MultiPolygon");
-                try {
-                    document.querySelector(".color-list li[title='" + (dnum + 1) + "'] div").className =
-                        "icon-list__item__radio " + (window.d_contiguity[dnum] ? "" : "contiguity");
-                } catch(e) {
-                }
-                // console.log(dnum + ": " + geomType);
+                // try {
+                //     document.querySelector(".color-list li[title='" + (dnum + 1) + "'] div").className =
+                //         "icon-list__item__radio " + (window.d_contiguity[dnum] ? "" : "contiguity");
+                // } catch(e) {
+                // }
             });
         });
     };

--- a/src/map/contiguity.js
+++ b/src/map/contiguity.js
@@ -1,4 +1,10 @@
 
+function setContiguityStatus(dnum, contiguous) {
+    try {
+        document.querySelector(`#contiguity-${dnum}`).style.display = contiguous ? "none" : "flex";
+    } catch(e) { }
+}
+
 export default function ContiguityChecker(state, brush) {
     const host = (window.location.hostname === "localhost") ? "https://deploy-preview-157--districtr-web.netlify.com" : "";
     if (!state.contiguity) {
@@ -29,10 +35,7 @@ export default function ContiguityChecker(state, brush) {
             if (!testIDs[dnum] || testIDs[dnum].length <= 1) {
                 // 0-1 precincts automatically OK
                 state.contiguity[dnum] = true;
-                // try {
-                //     document.querySelector(`.color-list li[title='${dnum + 1}'] div`).className = "icon-list__item__radio";
-                // } catch(e) {
-                // }
+                setContiguityStatus(dnum, true);
                 return;
             }
 
@@ -55,11 +58,16 @@ export default function ContiguityChecker(state, brush) {
                 let keys = Object.keys(data),
                     geomType = data[keys[0]];
                 state.contiguity[dnum] = (geomType !== "ST_MultiPolygon");
-                // try {
-                //     document.querySelector(".color-list li[title='" + (dnum + 1) + "'] div").className =
-                //         "icon-list__item__radio " + (window.d_contiguity[dnum] ? "" : "contiguity");
-                // } catch(e) {
-                // }
+                setContiguityStatus(dnum, state.contiguity[dnum]);
+            })
+            .catch((err) => {
+                // on localhost, no connection = random result, for UI testing
+                if (window.location.hostname === "localhost") {
+                    state.contiguity[dnum] = (Math.random() > 0.5);
+                    setContiguityStatus(dnum, state.contiguity[dnum]);
+                } else {
+                    console.error(err);
+                }
             });
         });
     };

--- a/src/map/contiguity.js
+++ b/src/map/contiguity.js
@@ -1,0 +1,73 @@
+
+export default function ContiguityChecker(state, brush) {
+    const host = (window.location.hostname === "localhost") ? "https://deploy-preview-157--districtr-web.netlify.com" : "";
+    window.d_contiguity = {};
+
+    const updater = (state, colorsAffected) => {
+        let assignment = state.plan.assignment,
+            place = state.place.id,
+            testIDs = {};
+
+        Object.keys(assignment).forEach((unit_id) => {
+            let districtNum = assignment[unit_id];
+            if (testIDs[districtNum]) {
+                testIDs[districtNum].push(unit_id);
+            } else {
+                testIDs[districtNum] = [unit_id];
+            }
+        });
+
+        // let my_tstamp = new Date();
+        colorsAffected.forEach((dnum) => {
+            if (!dnum && dnum !== 0) {
+                // avoid eraser
+                return;
+            }
+            if (!testIDs[dnum] || testIDs[dnum].length <= 1) {
+                // 0-1 precincts automatically OK
+                window.d_contiguity[dnum] = true;
+                try {
+                    document.querySelector(`.color-list li[title='${dnum + 1}'] div`).className = "icon-list__item__radio";
+                } catch(e) {
+                }
+                return;
+            }
+
+            fetch(host + "/.netlify/functions/planContiguity", {
+                method: "POST",
+                mode: "no-cors",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                    ids: testIDs[dnum].join(","),
+                    state: place
+                })
+            })
+            .then(res => res.json())
+            .then((data) => {
+                if (data.length) {
+                    data = data[0];
+                }
+                let keys = Object.keys(data),
+                    geomType = data[keys[0]];
+                window.d_contiguity[dnum] = (geomType !== "ST_MultiPolygon");
+                try {
+                    document.querySelector(".color-list li[title='" + (dnum + 1) + "'] div").className =
+                        "icon-list__item__radio " + (window.d_contiguity[dnum] ? "" : "contiguity");
+                } catch(e) {
+                }
+                // console.log(dnum + ": " + geomType);
+            });
+        });
+    };
+
+    let allDistricts = [],
+        i = 0;
+    while (i < state.problem.numberOfParts) {
+        allDistricts.push(i);
+        i++;
+    }
+    updater(state, allDistricts);
+    return updater;
+}

--- a/src/plugins/evaluation-plugin.js
+++ b/src/plugins/evaluation-plugin.js
@@ -67,6 +67,7 @@ export default function EvaluationPlugin(editor) {
             "Contiguity",
             (uiState, dispatch) =>
                 ContiguitySection(
+                    state.contiguity,
                     uiState,
                     dispatch
                 ),

--- a/src/plugins/evaluation-plugin.js
+++ b/src/plugins/evaluation-plugin.js
@@ -1,5 +1,6 @@
 import ElectionResultsSection from "../components/Charts/ElectionResultsSection";
 import RacialBalanceTable from "../components/Charts/RacialBalanceTable";
+import ContiguitySection from "../components/Charts/ContiguitySection";
 import { Tab } from "../components/Tab";
 
 export default function EvaluationPlugin(editor) {
@@ -60,6 +61,21 @@ export default function EvaluationPlugin(editor) {
             }
         );
     }
+
+    if (state.plan.problem.type !== "community") {
+        tab.addRevealSection(
+            "Contiguity",
+            (uiState, dispatch) =>
+                ContiguitySection(
+                    uiState,
+                    dispatch
+                ),
+            {
+                isOpen: true
+            }
+        );
+    }
+
     if (tab.sections.length > 0) {
         toolbar.addTab(tab);
     }

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -19,9 +19,36 @@ export default function ToolsPlugin(editor) {
     let planNumbers = NumberMarkers(state, brush);
     brush.on("colorop", (isUndoRedo, colorsAffected) => {
         savePlanToStorage(state.serialize());
+
         if (planNumbers) {
             planNumbers.update(state, colorsAffected);
         }
+
+        let districts = [],
+            i = 0;
+        while (i < state.problem.numberOfParts) {
+            districts.push(i);
+            i++;
+        }
+        let testIDs = [];
+        Object.keys(state.plan.assignment).forEach((unit_id) => {
+            if (state.plan.assignment[unit_id] === 1) {
+                testIDs.push(unit_id);
+            }
+        });
+        fetch("/.netlify/functions/planContiguity", {
+            method: "POST",
+            headers: {
+                "Content-Type": "application/json"
+            },
+            body: JSON.stringify({
+                ids: testIDs.join(",")
+            })
+        })
+        .then(res => res.json())
+        .then((data) => {
+            console.log(data[0].contiguity_pennsylvania);
+        });
     });
 
     let tools = [

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -4,7 +4,11 @@ import InspectTool from "../components/Toolbar/InspectTool";
 import PanTool from "../components/Toolbar/PanTool";
 import LandmarkTool from "../components/Toolbar/LandmarkTool";
 import Brush from "../map/Brush";
+<<<<<<< HEAD
 import NumberMarkers from "../map/NumberMarkers";
+=======
+import ContiguityChecker from "../map/contiguity";
+>>>>>>> indicate contiguity issues on control panel
 import { renderAboutModal, renderSaveModal } from "../components/Modal";
 import { navigateTo, savePlanToStorage, savePlanToDB } from "../routes";
 import { download } from "../utils";
@@ -17,8 +21,11 @@ export default function ToolsPlugin(editor) {
     brush.on("colorend", toolbar.unsave);
 
     let planNumbers = NumberMarkers(state, brush);
+    const c_checker = ContiguityChecker(state, brush);
     brush.on("colorop", (isUndoRedo, colorsAffected) => {
         savePlanToStorage(state.serialize());
+        
+        c_checker(state, colorsAffected);
 
         if (planNumbers) {
             planNumbers.update(state, colorsAffected);

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -4,11 +4,8 @@ import InspectTool from "../components/Toolbar/InspectTool";
 import PanTool from "../components/Toolbar/PanTool";
 import LandmarkTool from "../components/Toolbar/LandmarkTool";
 import Brush from "../map/Brush";
-<<<<<<< HEAD
 import NumberMarkers from "../map/NumberMarkers";
-=======
 import ContiguityChecker from "../map/contiguity";
->>>>>>> indicate contiguity issues on control panel
 import { renderAboutModal, renderSaveModal } from "../components/Modal";
 import { navigateTo, savePlanToStorage, savePlanToDB } from "../routes";
 import { download } from "../utils";
@@ -24,7 +21,7 @@ export default function ToolsPlugin(editor) {
     const c_checker = ContiguityChecker(state, brush);
     brush.on("colorop", (isUndoRedo, colorsAffected) => {
         savePlanToStorage(state.serialize());
-        
+
         c_checker(state, colorsAffected);
 
         if (planNumbers) {

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -32,22 +32,34 @@ export default function ToolsPlugin(editor) {
         }
         let testIDs = [];
         Object.keys(state.plan.assignment).forEach((unit_id) => {
-            if (state.plan.assignment[unit_id] === 1) {
-                testIDs.push(unit_id);
+            let districtNum = state.plan.assignment[unit_id];
+            if (testIDs[districtNum]) {
+                testIDs[districtNum].push(unit_id);
+            } else {
+                testIDs[districtNum] = [unit_id];
             }
         });
-        fetch("/.netlify/functions/planContiguity", {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json"
-            },
-            body: JSON.stringify({
-                ids: testIDs.join(",")
+
+        // let my_tstamp = new Date();
+        colorsAffected.forEach((dnum) => {
+            fetch("/.netlify/functions/planContiguity", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: JSON.stringify({
+                    ids: testIDs[dnum].join(","),
+                    state: state.place.id
+                })
             })
-        })
-        .then(res => res.json())
-        .then((data) => {
-            console.log(data[0].contiguity_pennsylvania);
+            .then(res => res.json())
+            .then((data) => {
+                if (data.length) {
+                    data = data[0];
+                }
+                let keys = Object.keys(data);
+                console.log(dnum + ": " + data[keys[0]]);
+            });
         });
     });
 


### PR DESCRIPTION
Working:
- POSTs a list of affected unit IDs to Netlify function -> PostgREST -> PostGIS for contiguity check
- covers states, Providence, and Chicago precincts
- UI showing which districts are non-contiguous

PostGIS function
```sql
CREATE FUNCTION api.contiguity_wisconsin(ids TEXT) RETURNS text AS $$
  SELECT ST_GeometryType(ST_Buffer(ST_Union(wkb_geometry), 0.000001))
  FROM api.wi_wards
  WHERE geoid10 = ANY(string_to_array(ids, ','))
$$ LANGUAGE SQL;
```