### PR TITLE
Make landmark tool easier to find and use

### DIFF
--- a/sass/components/_toolbar.scss
+++ b/sass/components/_toolbar.scss
@@ -326,3 +326,17 @@ li:first-child > input:checked ~ .tabs__tab {
     @include grey-hovers;
     @include user-select(none);
 }
+
+.mapbox-gl-draw_point {
+    background-color: rgb(250, 250, 120) !important;
+
+    &::after {
+        content: '+';
+        right: 0;
+        position: absolute;
+        top: -2px;
+        font-size: 13px;
+        color: darkgreen;
+        font-weight: bold;
+    }
+}

--- a/src/components/Toolbar/LandmarkTool.js
+++ b/src/components/Toolbar/LandmarkTool.js
@@ -64,6 +64,7 @@ export default class LandmarkTool extends Tool {
         super.activate();
         // enable / disable drawing toolbar
         this.landmarks.handleDrawToggle(true);
+        document.querySelector(".mapbox-gl-draw_point").click();
     }
     deactivate() {
         super.deactivate();
@@ -118,6 +119,7 @@ class LandmarkOptions {
         let saveButton = document.getElementById("landmark-save-button")
         saveButton.disabled = true;
         saveButton.innerText = "Saved";
+        document.querySelector(".mapbox-gl-draw_point").click();
     }
     onDelete() {
         // delete currently viewed shape
@@ -171,7 +173,7 @@ class LandmarkOptions {
         setName: this.setName,
         setDescription: this.setDescription,
         onDelete: this.onDelete
-    }) : "Add landmarks using the tool(s) on the top right of the map."}
+    }) : "Click on the map with the crosshairs (+) to add a point"}
         `;
     }
 }


### PR DESCRIPTION
- When opening the landmark tool, the "Add Point" button is now clicked for you. You should see a crosshairs (+) on the map to add the marker
- After clicking the 'Save' button on a landmark, the "Add Point" button is clicked for you
- The button is more visible and contains a + to make it more meaningful (screenshots below)

![Screen Shot 2020-02-03 at 10 45 16 AM](https://user-images.githubusercontent.com/643918/73667605-83392d80-4672-11ea-81a6-ce5d07f755e7.png)
![Screen Shot 2020-02-03 at 10 44 36 AM](https://user-images.githubusercontent.com/643918/73667612-86341e00-4672-11ea-80ad-7b22ca729f97.png)
