### PR TITLE
Consolidate multiple district counts into one button

### DIFF
--- a/assets/data/response.json
+++ b/assets/data/response.json
@@ -7436,6 +7436,16 @@
         "name": "City Council",
         "numberOfParts": 4,
         "pluralNoun": "City Council Districts"
+      },
+      {
+        "name": "City Council",
+        "numberOfParts": 5,
+        "pluralNoun": "City Council Districts"
+      },
+      {
+        "name": "City Council",
+        "numberOfParts": 7,
+        "pluralNoun": "City Council Districts"
       }
     ]
   },

--- a/sass/components/_places.scss
+++ b/sass/components/_places.scss
@@ -56,16 +56,15 @@
 
         button {
             cursor: pointer;
-            background-color: #0f1548;
-            color: white;
-            padding: 0.4rem 0.8rem;
+            background-color: #fff;
+            color: $mggg-blue;
+            padding: 0.2rem 0.6rem;
             margin: 0.2rem 0.5rem;
             border-radius: 0.2rem;
-            font-weight: bold;
-            font-size: 80%;
+            font-size: 100%;
 
             &:hover {
-                background-color: #4f1548;
+                background-color: #eee;
             }
         }
         &:hover {

--- a/sass/components/_places.scss
+++ b/sass/components/_places.scss
@@ -49,6 +49,29 @@
     &:hover {
         background-color: $mggg-dark-blue;
     }
+
+    &.choice {
+        cursor: default;
+        background-color: $mggg-blue;
+
+        button {
+            cursor: pointer;
+            background-color: #0f1548;
+            color: white;
+            padding: 0.4rem 0.8rem;
+            margin: 0.2rem 0.5rem;
+            border-radius: 0.2rem;
+            font-weight: bold;
+            font-size: 80%;
+
+            &:hover {
+                background-color: #4f1548;
+            }
+        }
+        &:hover {
+            background-color: $mggg-blue;
+        }
+    }
 }
 
 .communities {

--- a/src/routes.js
+++ b/src/routes.js
@@ -18,7 +18,10 @@ export function navigateTo(route) {
     }
 }
 
-export function startNewPlan(place, problem, units, id) {
+export function startNewPlan(place, problem, units, id, setParts) {
+    if (setParts) {
+        problem.numberOfParts = setParts;
+    }
     savePlanToStorage({ place, problem, units, id });
     navigateTo("/edit");
 }


### PR DESCRIPTION
This affects only City of Napa (California) and Lowell (MA)

![Screen Shot 2020-03-09 at 1 01 24 PM](https://user-images.githubusercontent.com/643918/76238567-69a57b80-6206-11ea-9dbe-9b348e6d8e10.png)

![Screen Shot 2020-03-09 at 1 01 34 PM](https://user-images.githubusercontent.com/643918/76238573-6ca06c00-6206-11ea-91ab-52854f3b4cd1.png)

- Massachusetts statewide is unchanged: old and new precincts are not combined
- Yakima is unchanged: different *units* (blocks and precincts) not combined
- Pennsylvania statewide is unchanged: different *names* were given to 2010 and prospective 2020 district counts (I can edit the config file if we would like to combine these)