### PR TITLE
Toggle neighborhood names in COI

### DIFF
--- a/src/components/Landmark.js
+++ b/src/components/Landmark.js
@@ -17,7 +17,7 @@ export function LandmarkInfo(features) {
 }
 
 const landmarkPaintProperty = {
-    "fill-opacity": 0, // turn off the highlights by default
+    "fill-opacity": 0.5, // turn off the highlights by default
     "fill-color": [
         "case",
         ["boolean", ["feature-state", "hover"], false],
@@ -27,7 +27,7 @@ const landmarkPaintProperty = {
 };
 
 const landmarkCircleProperty = {
-    'circle-opacity': 0,
+    'circle-opacity': 0.5,
     'circle-radius': 8,
     'circle-color': [
         "case",
@@ -39,7 +39,7 @@ const landmarkCircleProperty = {
 
 export class Landmarks {
     constructor(map, savedPlaces, updateLandmarkList) {
-        this.visible = false;
+        this.visible = true;
         this.savedPlaces = savedPlaces;
         this.updateLandmarkList = updateLandmarkList;
 
@@ -78,6 +78,7 @@ export class Landmarks {
             addBelowLabels
         );
         this.ptsTooltip = new Tooltip(this.markerlayer, LandmarkInfo, 5);
+        this.ptsTooltip.activate();
 
         // MapBox GL Draw tool
         this.drawTool = new MapboxDraw({

--- a/src/plugins/data-layers-plugin.js
+++ b/src/plugins/data-layers-plugin.js
@@ -408,6 +408,20 @@ export default function DataLayersPlugin(editor) {
         addAmerIndianLayer(tab, state);
     }
 
+    if (state.plan.problem.type === "community") {
+        tab.addSection(() => toggle("Neighborhood names", true, checked => {
+            state.map.setLayoutProperty('settlement-subdivision-label', 'text-field', checked ? ["get", "name"]
+                : ["case",
+                ["==", ["get", "type"], "neighborhood"],
+                "",
+                ["==", ["get", "type"], "neighbourhood"],
+                "",
+                ["==", ["get", "type"], "block"],
+                "",
+                ["get", "name"]]); // default
+        }));
+    }
+
     tab.addSection(() => html`<h4>Demographics</h4>`)
 
     let coalitionOverlays = [];

--- a/src/plugins/data-layers-plugin.js
+++ b/src/plugins/data-layers-plugin.js
@@ -53,7 +53,7 @@ export function addCountyLayer(tab, state) {
     if (stateNameToFips[(state.place.state || state.place.id).toLowerCase()]) {
         tab.addSection(
             () => html`
-                <h4>Counties</h4>
+                <h4>Boundaries</h4>
                 ${toggle(`Show county boundaries`, false, checked =>
                     counties.setOpacity(
                         checked ? COUNTIES_LAYER.paint["fill-opacity"] : 0
@@ -409,16 +409,18 @@ export default function DataLayersPlugin(editor) {
     }
 
     if (state.plan.problem.type === "community") {
-        tab.addSection(() => toggle("Neighborhood names", true, checked => {
+        const noNames = ["case",
+            ["==", ["get", "type"], "neighborhood"],
+            "",
+            ["==", ["get", "type"], "neighbourhood"],
+            "",
+            ["==", ["get", "type"], "block"],
+            "",
+            ["get", "name"]];
+        state.map.setLayoutProperty('settlement-subdivision-label', 'text-field', noNames);
+        tab.addSection(() => toggle("Suggest neighborhood names", false, checked => {
             state.map.setLayoutProperty('settlement-subdivision-label', 'text-field', checked ? ["get", "name"]
-                : ["case",
-                ["==", ["get", "type"], "neighborhood"],
-                "",
-                ["==", ["get", "type"], "neighbourhood"],
-                "",
-                ["==", ["get", "type"], "block"],
-                "",
-                ["get", "name"]]); // default
+                : noNames);
         }));
     }
 


### PR DESCRIPTION
Considering removing or toggling OSM/MapBox neighborhood names in COI view, as they may over-imply existing boundaries to mappers