### PR TITLE
Only one demographic/election layer visible at a time

### DIFF
--- a/src/layers/OverlayContainer.js
+++ b/src/layers/OverlayContainer.js
@@ -1,7 +1,6 @@
 import { html } from "lit-html";
 import Parameter from "../components/Parameter";
 import Select from "../components/Select";
-import { toggle } from "../components/Toggle";
 import { colorByCount, purpleByCount, colorByFraction } from "./color-rules";
 import Overlay from "./Overlay";
 
@@ -81,16 +80,35 @@ export default class OverlayContainer {
             });
         }
 
-        this.visibilityToggle = toggle(toggleText, (!this.firstOnly && this._currentSubgroupIndex !== 0), visible => {
-            document.getElementById("color-" + this._id).style.display
-                = (visible ? "block" : "none");
-            if (visible) {
-                this.overlay.show();
-                this.changeSubgroup(this._currentSubgroupIndex);
-            } else {
-                this.overlay.hide();
-            }
-        });
+        this.visibilityToggle = html`<label class="toolbar-checkbox">
+            <input
+                type="checkbox"
+                name="data_layers"
+                ?checked="${!this.firstOnly && this._currentSubgroupIndex !== 0}"
+                value="${this._id}"
+                @change=${(e) => {
+                    if (e.bubbles) {
+                        let checks = document.getElementsByName("data_layers");
+                        for (let c = 0; c < checks.length; c++) {
+                            if (checks[c].value !== this._id) {
+                                checks[c].checked = false;
+                                let evt = new Event("change");
+                                checks[c].dispatchEvent(evt);
+                            }
+                        }
+                    }
+                    let visible = e.target.checked;
+                    document.getElementById("color-" + this._id).style.display = (visible ? "block" : "none");
+                    if (visible) {
+                        this.overlay.show();
+                        this.changeSubgroup(this._currentSubgroupIndex);
+                    } else {
+                        this.overlay.hide();
+                    }
+                }}
+            />
+            ${toggleText}
+        </label>`;
     }
     changeSubgroup(i) {
         this._currentSubgroupIndex = i;

--- a/src/layers/PartisanOverlayContainer.js
+++ b/src/layers/PartisanOverlayContainer.js
@@ -1,7 +1,6 @@
 import { html } from "lit-html";
 import { Parameter } from "../components/Parameter";
 import Select from "../components/Select";
-import { toggle } from "../components/Toggle";
 import PartisanOverlay from "./PartisanOverlay";
 import { getLayerDescription } from "./OverlayContainer";
 
@@ -55,9 +54,28 @@ export default class PartisanOverlayContainer {
         const overlay = this.currentElectionOverlay;
         return html`
             <div class="ui-option ui-option--slim">
-                ${toggle(`Show partisan lean`, overlay.isVisible, checked =>
-                    this.toggleVisibility(checked)
-                )}
+                <label class="toolbar-checkbox">
+                    <input
+                        type="checkbox"
+                        name="data_layers"
+                        ?checked="${overlay.isVisible}"
+                        value="partisan"
+                        @change=${(e) => {
+                            if (e.bubbles) {
+                                let checks = document.getElementsByName("data_layers");
+                                for (let c = 0; c < checks.length; c++) {
+                                    if (checks[c].value !== this._id) {
+                                        checks[c].checked = false;
+                                        let evt = new Event("change");
+                                        checks[c].dispatchEvent(evt);
+                                    }
+                                }
+                            }
+                            this.toggleVisibility(e.target.checked);
+                        }}
+                    />
+                    Show partisan lean
+                </label>
             </div>
             ${[
                 {


### PR DESCRIPTION
Test for individual editing. Works in Chrome and desktop Safari
I ended up not making these into radio buttons because it was unclear how to turn off all demographic layers