### PR TITLE
Extend spatial features to more modules

### DIFF
--- a/assets/about/delaware/precincts.html
+++ b/assets/about/delaware/precincts.html
@@ -1,0 +1,13 @@
+<p>
+The units you see here are <strong>precincts</strong>.
+</p>
+
+<p>
+  This shapefile was obtained from the Delaware FirstMap Data website and processed by members of the Metric Geometry and Gerrymandering Group (MGGG).
+</p>
+<p>
+  The Delaware election district (precinct) shapefile was obtained from Delaware FirstMap Data, a GIS service of the State of Delaware. Election data come from the Delaware Department of Elections. 2010 Decennial Census demographic data were downloaded from the Census API. The 2010 census block shapefile for Delaware was downloaded from the US Census Bureau’s TIGER/Line Shapefiles.
+</p>
+<p>
+  Some very limited merging of precincts in the tabular election data was necessary to join to the precinct shapefile. Data from three countywide precincts that reported absentee votes were disaggregated by voting age population using MGGG’s proration software. Demographic data was aggregated from the block level using MGGG’s proration software. State legislative district IDs were also assigned to precincts using this package.
+</p>

--- a/assets/data/response.json
+++ b/assets/data/response.json
@@ -5373,6 +5373,12 @@
                 "max": 236
               }
             ]
+          },
+          {
+            "type": "text",
+            "key": "county_nam",
+            "name": "County",
+            "subgroups": []
           }
         ],
         "idColumn": {

--- a/assets/native_official/minnesota_centroids.geojson
+++ b/assets/native_official/minnesota_centroids.geojson
@@ -9,6 +9,7 @@
 { "type": "Feature", "properties": { "NAME": "Shakopee Mdewakanton Sioux" }, "geometry": { "type": "Point", "coordinates": [ -93.472395918780236, 44.737569243495876 ] } },
 { "type": "Feature", "properties": { "NAME": "Lower Sioux" }, "geometry": { "type": "Point", "coordinates": [ -94.987666788134518, 44.530132711142116 ] } },
 { "type": "Feature", "properties": { "NAME": "Leech Lake" }, "geometry": { "type": "Point", "coordinates": [ -94.256708410803199, 47.355612915991756 ] } },
+{ "type": "Feature", "properties": { "NAME": "Lake Traverse" }, "geometry": { "type": "Point", "coordinates": [ -97.098594508157092, 45.645444719722171 ] } },
 { "type": "Feature", "properties": { "NAME": "White Earth" }, "geometry": { "type": "Point", "coordinates": [ -95.721738442559186, 47.227602928249119 ] } },
 { "type": "Feature", "properties": { "NAME": "Bois Forte" }, "geometry": { "type": "Point", "coordinates": [ -92.335683002996547, 47.81956123414578 ] } },
 { "type": "Feature", "properties": { "NAME": "Bois Forte" }, "geometry": { "type": "Point", "coordinates": [ -93.187020361075525, 48.09187755577981 ] } },

--- a/assets/native_official/nc_centroids.geojson
+++ b/assets/native_official/nc_centroids.geojson
@@ -55,6 +55,8 @@
 { "type": "Feature", "properties": { "NAME": "Sappony" }, "geometry": { "type": "Point", "coordinates": [ -78.858364015115313, 36.493057753137727 ] } },
 { "type": "Feature", "properties": { "NAME": "Meherrin" }, "geometry": { "type": "Point", "coordinates": [ -76.948173565445487, 36.337542655039307 ] } },
 { "type": "Feature", "properties": { "NAME": "Occaneechi-Saponi" }, "geometry": { "type": "Point", "coordinates": [ -79.265313794926101, 35.997876687856298 ] } },
-{ "type": "Feature", "properties": { "NAME": "Occaneechi-Saponi" }, "geometry": { "type": "Point", "coordinates": [ -79.256913839836386, 36.187218298049395 ] } }
+{ "type": "Feature", "properties": { "NAME": "Occaneechi-Saponi" }, "geometry": { "type": "Point", "coordinates": [ -79.256913839836386, 36.187218298049395 ] } },
+{ "type": "Feature", "properties": { "NAME": "Upper South Carolina Pee Dee" }, "geometry": { "type": "Point", "coordinates": [ -79.415969337643517, 34.527584649850063 ] } },
+{ "type": "Feature", "properties": { "NAME": "Pee Dee" }, "geometry": { "type": "Point", "coordinates": [ -79.655643049498437, 34.710521486310249 ] } }
 ]
 }

--- a/src/map/Brush.js
+++ b/src/map/Brush.js
@@ -98,11 +98,10 @@ export default class Brush extends HoverWithRadius {
                             return name.join(" ");
                         };
                     [countyProp, countyFIPS] = idSearch("GEOID10", 5)
+                        || idSearch("county_nam") // Michigan
                         || idSearch("VTD", 5)
                         || idSearch("VTDID", 5)
                         // || idSearch("CNTYVTD", 3)
-                        // || idSearch("DsslvID", 2) // Utah
-                        // || idSearch("PRECODE", 2) // Oklahoma
                         || idSearch("COUNTYFP10")
                         || idSearch("COUNTY")
                         || idSearch("CTYNAME")

--- a/src/map/Layer.js
+++ b/src/map/Layer.js
@@ -99,12 +99,13 @@ export default class Layer {
                 "all",
                 ["has", countyProp]
             ];
-        if (["COUNTY", "CTYNAME", "CNTYNAME", "COUNTYFP10", "cnty_nm", "locality"].includes(countyProp)) {
+        if (["COUNTY", "CTYNAME", "CNTYNAME", "COUNTYFP10", "cnty_nm", "county_nam", "locality"].includes(countyProp)) {
             filterStrings.push(["==", ["get", countyProp], fips]);
         } else {
             filterStrings.push([">=", ["get", countyProp], fips]);
             filterStrings.push(["<", ["get", countyProp], ((isNaN(fips * 1) || countyProp.toLowerCase().includes("name")) ? fips + "z" : String(Number(fips) + 1))]);
         }
+
         this.map.querySourceFeatures(this.sourceId, {
             sourceLayer: this.sourceLayer,
             filter: filterStrings

--- a/src/map/NumberMarkers.js
+++ b/src/map/NumberMarkers.js
@@ -10,7 +10,7 @@ export default function NumberMarkers(state, brush) {
     if (!spatial_abilities(state.place.id).number_markers) {
         console.log("not on NumberMarkers allowlist");
         return;
-    } else if (["arizona", "ma"].includes(state.place.id) && !state.units.sourceId.includes("precinct")) {
+    } else if (["ma"].includes(state.place.id) && !state.units.sourceId.includes("precinct")) {
         console.log("state NumberMarker support limited to precincts");
         return;
     }

--- a/src/map/NumberMarkers.js
+++ b/src/map/NumberMarkers.js
@@ -8,7 +8,10 @@ export default function NumberMarkers(state, brush) {
         return;
     }
     if (!spatial_abilities(state.place.id).number_markers) {
-        console.log("not on NumberMarkers whitelist");
+        console.log("not on NumberMarkers allowlist");
+        return;
+    } else if (["arizona", "ma"].includes(state.place.id) && !state.units.sourceId.includes("precinct")) {
+        console.log("state NumberMarker support limited to precincts");
         return;
     }
 
@@ -19,7 +22,7 @@ export default function NumberMarkers(state, brush) {
         districts = [],
         dpr = window.devicePixelRatio || 1,
         map = state.units.map;
-    canv.height = 22;
+    canv.height = 22 * dpr;
     ctx.scale(dpr, dpr);
     if (typeof ctx.ellipse === "undefined") {
         // IE helper
@@ -31,13 +34,14 @@ export default function NumberMarkers(state, brush) {
         i++;
     }
     districts.forEach((dnum) => {
-        canv.width = 32;
-        ctx.strokeStyle = "#000";
+        canv.width = 32 * dpr;
+        // ctx.translate(0.5, 0.5);
+        // ctx.strokeStyle = "#000";
         ctx.fillStyle = "#fff";
-        ctx.lineWidth = 2;
+        // ctx.lineWidth = 1;
         ctx.ellipse(16, 11, 14, 10, 0, 0, 2 * Math.PI);
         ctx.fill();
-        ctx.stroke();
+        // ctx.stroke();
         ctx.fillStyle = "#000";
         ctx.font = "14px sans-serif";
         ctx.fillText(
@@ -45,9 +49,6 @@ export default function NumberMarkers(state, brush) {
             16 - ctx.measureText(dnum + 1).width / 2,
             16
         );
-        // if (!dnum) {
-        //     console.log(canv.toDataURL());
-        // }
 
         map.addSource("number_source_" + dnum, {
             type: "geojson",

--- a/src/map/contiguity.js
+++ b/src/map/contiguity.js
@@ -21,23 +21,21 @@ export default function ContiguityChecker(state, brush) {
 
   const updater = (state, colorsAffected) => {
     let saveplan = state.serialize();
-    if (["iowa", "texas"].includes(state.place.id)) {
-      const GERRYCHAIN_URL = "//mggg.pythonanywhere.com";
-      fetch(GERRYCHAIN_URL, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(saveplan),
-      })
-        .then((res) => res.json())
-        .catch((e) => console.error(e))
-        .then((data) => {
-          console.log(data);
-          setContiguityStatus(data, -999);
-          return data;
-        });
-    }
+    const GERRYCHAIN_URL = "//mggg.pythonanywhere.com";
+    fetch(GERRYCHAIN_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(saveplan),
+    })
+      .then((res) => res.json())
+      .catch((e) => console.error(e))
+      .then((data) => {
+        console.log(data);
+        setContiguityStatus(data, -999);
+        return data;
+      });
   };
 
   let allDistricts = [],

--- a/src/plugins/data-layers-plugin.js
+++ b/src/plugins/data-layers-plugin.js
@@ -122,15 +122,15 @@ export function addAmerIndianLayer(tab, state) {
         native_am_type = "Alaskan Native Communities";
     } else if (["california"].includes(state.place.id)) {
         native_am_type = "Indian Communities";
-    } else if (["alabama", "colorado", "florida", "georgia", "idaho", "iowa", "kansas", "louisiana", "nebraska", "southcarolina", "southdakota", "virginia", "wisconsin", "wyoming"].includes(state.place.id)) {
+    } else if (["alabama", "colorado", "florida", "georgia", "idaho", "iowa", "kansas", "louisiana", "nebraska", "southcarolina", "southdakota", "wyoming"].includes(state.place.id)) {
         native_am_type = "Tribes";
-    } else if (["montana", "oregon"].includes(state.place.id)) {
+    } else if (["connecticut", "delaware", "montana", "oregon", "virginia", "wisconsin"].includes(state.place.id)) {
         native_am_type = "Tribal Nations";
     } else if (state.place.id === "hawaii") {
         native_am_type = "Hawaiian Home Lands";
     } else if (state.place.id === "oklahoma") {
         native_am_type = "Indian Country";
-    } else if (["connecticut", "delaware", "maine", "nevada", "newyork", "utah"].includes(state.place.id)) {
+    } else if (["maine", "nevada", "newyork", "utah"].includes(state.place.id)) {
         native_am_type = "Indian Tribes";
     } else if (state.place.id === "texas") {
         native_am_type = "Indian Nations";
@@ -142,6 +142,8 @@ export function addAmerIndianLayer(tab, state) {
         native_am_type = "Tribal Communities";
     } else if (state.place.id === "northdakota") {
         native_am_type = "Tribes and Communities";
+    } else if (state.place.id === "mississippi") {
+        native_am_type = "Mississippi Band of Choctaw Indians";
     }
 
     const shared_az = {

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -34,7 +34,9 @@ export default function ToolsPlugin(editor) {
     const c_checker = ContiguityChecker(state, brush);
     brush.on("colorop", (isUndoRedo, colorsAffected) => {
         savePlanToStorage(state.serialize());
-        c_checker(state, colorsAffected);
+        if (spatial_abilities(state.place.id).contiguity) {
+            c_checker(state, colorsAffected);
+        }
 
         if (planNumbers) {
             planNumbers.update(state, colorsAffected);

--- a/src/utils.js
+++ b/src/utils.js
@@ -321,7 +321,7 @@ export function spatial_abilities (id) {
       michigan: {
         number_markers: true,
         native_american: true,
-        // precode? county fix!
+        county_brush: true,
       },
       minnesota: {
         number_markers: true,

--- a/src/utils.js
+++ b/src/utils.js
@@ -248,22 +248,27 @@ export function spatial_abilities (id) {
           maricopa: {
             native_american: true,
             coalition: true,
+            number_markers: true,
           },
           nwaz: {
             native_american: true,
             coalition: true,
+            number_markers: true,
           },
           seaz: {
             native_american: true,
             coalition: true,
+            number_markers: true,
           },
           phoenix: {
             native_american: true,
             coalition: true,
+            number_markers: true,
           },
           yuma: {
             native_american: true,
             coalition: true,
+            number_markers: true,
           },
       chicago: {
         number_markers: true,

--- a/src/utils.js
+++ b/src/utils.js
@@ -240,7 +240,7 @@ export function spatial_abilities (id) {
         native_american: true,
       },
       arizona: {
-        // number_markers: true,
+        number_markers: true,
         county_brush: true,
         native_american: true,
         coalition: true,
@@ -271,9 +271,15 @@ export function spatial_abilities (id) {
       colorado: {
         number_markers: true,
         county_brush: true,
+        native_american: true,
       },
       connecticut: {
         county_brush: true,
+        native_american: true,
+        number_markers: true,
+      },
+      delaware: {
+        number_markers: true,
         native_american: true,
       },
       georgia: {
@@ -289,6 +295,9 @@ export function spatial_abilities (id) {
         number_markers: true,
         contiguity: true,
       },
+      little_rock: {
+        number_markers: true,
+      },
       maryland: {
         number_markers: true,
         county_brush: true,
@@ -297,20 +306,33 @@ export function spatial_abilities (id) {
         number_markers: true,
         // modern precincts, towns have issues
       },
+      miamifl: {
+        number_markers: true,
+      },
       miamidade: {
-        multiyear: true
+        multiyear: true,
+        number_markers: true,
       },
       michigan: {
         number_markers: true,
-        // precode?
+        native_american: true,
+        // precode? county fix!
       },
       minnesota: {
         number_markers: true,
         county_brush: true,
+        native_american: true,
       },
       mississippi: {
         number_markers: true,
         county_brush: true,
+        native_american: true,
+      },
+      napa: {
+        number_markers: true,
+      },
+      napaschools: {
+        number_markers: true,
       },
       new_mexico: {
         number_markers: true,
@@ -324,6 +346,7 @@ export function spatial_abilities (id) {
       nc: {
         number_markers: true,
         county_brush: true,
+        native_american: true,
       },
       ohio: {
         number_markers: true,
@@ -334,9 +357,13 @@ export function spatial_abilities (id) {
         native_american: true,
         county_brush: true,
       },
+      ontarioca: {
+        number_markers: true,
+      },
       oregon: {
         number_markers: true,
         county_brush: true,
+        native_american: true,
       },
       pennsylvania: {
         number_markers: true,
@@ -353,6 +380,7 @@ export function spatial_abilities (id) {
       utah: {
         number_markers: true,
         county_brush: true,
+        native_american: true,
       },
       vermont: {
         number_markers: true,
@@ -361,6 +389,7 @@ export function spatial_abilities (id) {
       virginia: {
         number_markers: true,
         county_brush: true,
+        native_american: true,
       },
       washington: {
         number_markers: true,
@@ -370,6 +399,7 @@ export function spatial_abilities (id) {
       wisconsin: {
         number_markers: true,
         county_brush: true,
+        native_american: true,
       },
   };
   return status[id] || {};

--- a/src/utils.js
+++ b/src/utils.js
@@ -282,10 +282,12 @@ export function spatial_abilities (id) {
         county_brush: true,
         native_american: true,
         number_markers: true,
+        contiguity: true,
       },
       delaware: {
         number_markers: true,
         native_american: true,
+        contiguity: true,
       },
       georgia: {
         number_markers: true,
@@ -361,6 +363,8 @@ export function spatial_abilities (id) {
         number_markers: true,
         native_american: true,
         county_brush: true,
+        contiguity: true,
+        coalition: true,
       },
       ontarioca: {
         number_markers: true,


### PR DESCRIPTION
Changes number markers to sharp white oval (no pixelly black border)

Adds number markers to: Arizona (statewide-precinct and smaller block modules (NW, SE, Maricopa, Phoenix, Yuma)), Arkansas (Little Rock), California (Napa, Napa Schools, Ontario), Connecticut, Delaware, Florida (Miami and Miami-Dade)

Adds Native Americans layer to: Arizona/Yuma ([Nations and Tribes](https://gotr.azgovernor.gov/gotr/indian-nations-and-tribes-legislative-day)), Colorado ([Tribes](https://www.colorado.gov/pacific/ccia/tribes)), Delaware (Tribal Nations), Michigan ([Tribal Governments](https://www.michigan.gov/som/0,4669,7-192-29701_41909---,00.html)), Minnesota ([Tribal Governments](https://www.sos.state.mn.us/about-minnesota/minnesota-government/tribal-government/)), Mississippi (Mississippi Band of Choctaw Indians), North Carolina (Tribal Communities - I thought we had this already but it was only COI), Oregon (Tribal Nations), Utah ([Indian Tribes](https://utah.com/culture/native-american-tribes)), Virginia (Tribal Nations), Wisconsin ([Tribal Nations](https://dpi.wi.gov/amind/tribalnationswi))

County paint for Michigan

About page for Delaware