### PR TITLE
Demo: redesign Share/Save button

### DIFF
--- a/sass/app.scss
+++ b/sass/app.scss
@@ -136,7 +136,7 @@ select {
         cursor: default;
     }
     &.updated {
-        background-color: #eef;
+        background-color: #ffda5d;
     }
 }
 

--- a/src/components/Modal.js
+++ b/src/components/Modal.js
@@ -33,33 +33,39 @@ export function renderSaveModal(state, exportPlanToDB) {
         let withUrl = (_id) => {
             render(renderModal(
                 html`
-                    <h2>Share Plan</h2>
+                    <h2>Plan is Saved</h2>
                     You can share your current plan by copying this URL:
                     <code>https://${window.location.host}/edit/${_id}</code>
                     <br/>
-                    <label>Have an event code?</label>
-                    <input
-                        id="event-coder"
-                        type="text"
-                        class="text-input"
-                        value=""
-                        @input="${() => document.getElementById("re-save").disabled = false}"
-                    />
-                    <br/>
-                    <button
-                        id="re-save"
-                        disabled
-                        @click="${() => {
-                            exportPlanToDB(
-                                state,
-                                document.getElementById("event-coder").value,
-                                () => { console.log("added event code"); }
-                            );
-                            render("", target);
-                        }}"
-                    >
-                        Add to Event
-                    </button>
+                    <label>
+                        <input id="save_modal_check" type="checkbox"/>
+                        Optional: can Districtr share this plan with local groups?
+                    </label>
+                    <div style="display:none">
+                        <label>Have an event code?</label>
+                        <input
+                            id="event-coder"
+                            type="text"
+                            class="text-input"
+                            value=""
+                            @input="${() => document.getElementById("re-save").disabled = false}"
+                        />
+                        <br/>
+                        <button
+                            id="re-save"
+                            disabled
+                            @click="${() => {
+                                exportPlanToDB(
+                                    state,
+                                    document.getElementById("event-coder").value,
+                                    () => { console.log("added event code"); }
+                                );
+                                render("", target);
+                            }}"
+                        >
+                            Add to Event
+                        </button>
+                    </div>
                 `
             ), target);
         };

--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -62,7 +62,7 @@ export default class Toolbar {
         // only need to update the button if user previously saved state
         // and we now need to allow an update
         if (btn.innerText === "Saved") {
-            btn.innerText = "Update";
+            btn.innerText = "Save Changes";
             btn.className = "updated";
         }
     }
@@ -90,7 +90,7 @@ export default class Toolbar {
                         class="unsaved"
                         @click="${this.savePlan.bind(this)}"
                     >
-                        Share
+                        Save
                     </div>
                     <div id="save-popup">
                         <button
@@ -105,29 +105,35 @@ export default class Toolbar {
                         You can share your current plan by copying this URL:
                         <code id="code-popup"></code>
                         <br/>
-                        <label>Have an event code?</label>
-                        <input
-                            id="event-coder-popup"
-                            type="text"
-                            class="text-input"
-                            value=""
-                            @input="${() => document.getElementById("re-save-popup").disabled = false}"
-                        />
-                        <br/>
-                        <button
-                            id="re-save-popup"
-                            disabled
-                            @click="${() => {
-                                document.getElementById("save-popup").className = "hide";
-                                savePlanToDB(
-                                    this.state,
-                                    document.getElementById("event-coder-popup").value,
-                                    () => { console.log("added event code"); }
-                                );
-                            }}"
-                        >
-                            Add to Event
-                        </button>
+                        <label>
+                            <input id="save_pop_check" type="checkbox"/>
+                            Optional: can Districtr share this plan with local groups?
+                        </label>
+                        <div style="display:none">
+                            <label>Have an event code?</label>
+                            <input
+                                id="event-coder-popup"
+                                type="text"
+                                class="text-input"
+                                value=""
+                                @input="${() => document.getElementById("re-save-popup").disabled = false}"
+                            />
+                            <br/>
+                            <button
+                                id="re-save-popup"
+                                disabled
+                                @click="${() => {
+                                    document.getElementById("save-popup").className = "hide";
+                                    savePlanToDB(
+                                        this.state,
+                                        document.getElementById("event-coder-popup").value,
+                                        () => { console.log("added event code"); }
+                                    );
+                                }}"
+                            >
+                                Add to Event
+                            </button>
+                        </div>
                     </div>
                     ${DropdownMenuButton(dropdownMenuOpen, this.store.dispatch)}
                 </div>

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -148,7 +148,7 @@ function getMenuItems(state) {
         },
         {
             id: "mobile-upload",
-            name: "Share plan",
+            name: "Save plan",
             onClick: () => renderSaveModal(state, savePlanToDB)
         }
     ];


### PR DESCRIPTION
Changes "Share" button to "Save"

![Screen Shot 2020-08-25 at 11 19 41 AM](https://user-images.githubusercontent.com/643918/91193638-52c7e800-e6c5-11ea-927f-db0cc46d2a64.png)

Share URL appears, unused "Event Code" box is replaced with opt-in to share with local orgs

![Screen Shot 2020-08-25 at 11 19 47 AM](https://user-images.githubusercontent.com/643918/91193636-52c7e800-e6c5-11ea-908e-095fefe55cf5.png)

After changing the map, the button turns orange to remind you to save changes. There will be enough space on the toolbar if COI merges Community and Landmark options

![Screen Shot 2020-08-25 at 11 19 56 AM](https://user-images.githubusercontent.com/643918/91193634-522f5180-e6c5-11ea-8891-96642e024820.png)

