### PR TITLE
Menu option to export shapefile

### DIFF
--- a/src/components/Toolbar/Toolbar.js
+++ b/src/components/Toolbar/Toolbar.js
@@ -67,7 +67,7 @@ export default class Toolbar {
         }
     }
     setMenuItems(menuItems) {
-        this.menuItems = menuItems;
+        this.menuItems = menuItems.filter(m => m !== null);
     }
     setState(state) {
         this.state = state;

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -111,6 +111,26 @@ function exportPlanAsJSON(state) {
     const text = JSON.stringify(serialized);
     download(`districtr-plan-${serialized.id}.json`, text);
 }
+function exportPlanAsSHP(state) {
+    const serialized = state.serialize();
+    Object.keys(serialized.assignment).forEach((assign) => {
+        if (typeof serialized.assignment[assign] === 'number') {
+            serialized.assignment[assign] = [serialized.assignment[assign]];
+        }
+    });
+    fetch("//mggg.pythonanywhere.com/shp", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(serialized),
+    })
+    .then((res) => res.arrayBuffer())
+    .catch((e) => console.error(e))
+    .then((data) => {
+        download(`districtr-plan-${serialized.id}.shp.zip`, data, true);
+    });
+}
 
 function exportPlanAsAssignmentFile(state, delimiter = ",", extension = "csv") {
     let text = `"id-${state.place.id}-${state.units.id}-${state.problem.numberOfParts}`;
@@ -144,6 +164,10 @@ function getMenuItems(state) {
             name: "Export plan as JSON",
             onClick: () => exportPlanAsJSON(state)
         },
+        (spatial_abilities(state.place.id).contiguity || spatial_abilities(state.place.id).screenshot) ?  {
+            name: "Export plan as SHP",
+            onClick: () => exportPlanAsSHP(state)
+        } : null,
         {
             name: "Export assignment as CSV",
             onClick: () => exportPlanAsAssignmentFile(state)

--- a/src/utils.js
+++ b/src/utils.js
@@ -136,11 +136,19 @@ export function generateId(len) {
     return Array.from(arr, dec2hex).join("");
 }
 
-export function download(filename, text) {
+export function download(filename, text, isbinary) {
+    let blob;
+    if (isbinary) {
+      blob = new Blob([text], {
+        type: 'application/octet-stream'
+      });
+    }
     let element = document.createElement("a");
     element.setAttribute(
         "href",
-        "data:text/plain;charset=utf-8," + encodeURIComponent(text)
+        isbinary
+          ? window.URL.createObjectURL(blob)
+          : "data:text/plain;charset=utf-8," + encodeURIComponent(text)
     );
     element.setAttribute("download", filename);
 


### PR DESCRIPTION
- Use the dropdown menu in the top right to Export as SHP
- Wait a minute for Maryland, possibly longer for other large states
- Result is a ZIP which contains the state shapefile, with a new "districtr" column; values are -1 for unset units, and start at 1 for districts

This will attempt to run in any map where we've uploaded a shapefile: Colorado, Connecticut, Delaware, Forsyth NC, Georgia, Iowa, Los Angeles County, Maryland, Mississippi, New Mexico, North Carolina redistricting, Oklahoma, Oregon, Portland OR, Pennsylvania, Philadelphia, and Texas

This doesn't yet solve one of our requests, to import each district or community as its own layer