### PR TITLE
Capitalize Subhead above "About Districtr" in Index

### DIFF
--- a/html/index.html
+++ b/html/index.html
@@ -313,7 +313,7 @@ strong {
             ></section>
             <section class="l-content l-major-section">
               <p style="text-align: right;">
-                <a href="/import-export">Import an existing plan or community map</a>
+                <a href="/import-export">Import an Existing Plan or Community Map</a>
               </p>
               <p style="text-align: right;">
                 <a href="/features">Features Available by Jurisdiction</a>


### PR DESCRIPTION
Capitalizes subhead in the "Where would you like to start?" section right above the "About Districtr" section for style purposes