### PR TITLE
Speedup builds (dev builds are at 1.73 sec)

### DIFF
--- a/build/bundle-js.js
+++ b/build/bundle-js.js
@@ -58,22 +58,3 @@ export default function bundleViews(production = true, caches) {
 	})
     );
 }
-
-/*
-export default function bundleViews(production = true, caches) {
-    return new Promise((resolve, reject) =>
-        fs.readdir("./src/views/", (err, files) => {
-            if (err) {
-                reject(err);
-            }
-            return resolve(files.map(filename => filename.split(".")[0]));
-        })
-    ).then(views =>
-        Promise.all(
-            views.map(view =>
-                bundleView(view, production, caches ? caches[view] : null)
-            )
-        )
-    );
-}
-*/

--- a/build/bundle-js.js
+++ b/build/bundle-js.js
@@ -1,11 +1,17 @@
 import fs from "fs";
+import gulp from "gulp";
 import { rollup } from "rollup";
 import plugins from "./rollup-plugins";
+import async from "async";
 
 const IE_TARGETS = "> 0.25%, last 2 versions, Firefox ESR, not dead";
 const MODERN_TARGETS =
     "> 0.25%, last 2 versions, Firefox ESR, not dead, not ie < 999";
 
+// We could run rollup twice in parallel (for production builds), 
+// but it is unknown if there will be race conditions, etc.
+// For production builds, it's probably safer to call bundle.write 
+// in sequence for now.
 export function bundleView(view, production = true, cache) {
     return (
         rollup({
@@ -17,32 +23,43 @@ export function bundleView(view, production = true, cache) {
                 warn(warning);
             }
         }).then(bundle =>
-            bundle.write({
-                file: `./dist/es5/${view}.js`,
-                format: "umd",
-                name: "ieBundle",
-                sourcemap: production
-            })
-        ),
-        rollup({
-            input: `./src/views/${view}.js`,
-            plugins: plugins(MODERN_TARGETS, !production),
-            cache: !production ? cache : false,
-            onwarn: (warning, warn) => {
-                if (warning.code === 'CIRCULAR_DEPENDENCY') return;
-                warn(warning);
-            }
-        }).then(bundle =>
-            bundle.write({
-                file: `./dist/es6/${view}.js`,
-                format: "umd",
-                name: "bundle",
-                sourcemap: production
-            })
+		{
+		    bundle.write({
+			file: `./dist/es5/${view}.js`,
+			format: "umd",
+			name: "ieBundle",
+			sourcemap: production
+		    });
+		    if (production) {
+		        bundle.write({
+		            file: `./dist/es6/${view}.js`,
+			    format: "umd",
+			    name: "bundle",
+			    sourcemap: production
+		        });
+		    }
+		}
         )
     );
 }
 
+
+export default function bundleViews(production = true, caches) {
+    return new Promise((resolve, reject) =>
+        fs.readdir("./src/views/", (err, files) => {
+            if (err) {
+                reject(err);
+            }
+            return resolve(files.map(filename => filename.split(".")[0]));
+        })
+    ).then(views =>
+	async.mapSeries(views, function (view) {
+            bundleView(view, production, caches ? caches[view] : null)
+	})
+    );
+}
+
+/*
 export default function bundleViews(production = true, caches) {
     return new Promise((resolve, reject) =>
         fs.readdir("./src/views/", (err, files) => {
@@ -59,3 +76,4 @@ export default function bundleViews(production = true, caches) {
         )
     );
 }
+*/

--- a/build/bundle-js.js
+++ b/build/bundle-js.js
@@ -24,19 +24,19 @@ export function bundleView(view, production = true, cache) {
             }
         }).then(bundle =>
 		{
+		bundle.write({
+		    file: `./dist/es6/${view}.js`,
+		    format: "umd",
+		    name: "bundle",
+		    sourcemap: production
+		});
+		    if (production) {
 		    bundle.write({
 			file: `./dist/es5/${view}.js`,
 			format: "umd",
 			name: "ieBundle",
 			sourcemap: production
 		    });
-		    if (production) {
-		        bundle.write({
-		            file: `./dist/es6/${view}.js`,
-			    format: "umd",
-			    name: "bundle",
-			    sourcemap: production
-		        });
 		    }
 		}
         )

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -9,15 +9,18 @@ import {
     serve
 } from "./build/dev-server";
 
+var exec = require('child_process').exec;
+
 const sources = {
     js: "./src/**/*.js",
     css: "./sass/**/*.scss",
     html: "./html/*.html",
-    assets: "./assets/**",
+    assets: "./assets",
     deployFiles: "./deploy/**"
 };
 
 export const clean = () => new Promise(resolve => fs.rmdir("./dist", resolve));
+export const mkdir = () => new Promise(resolve => fs.mkdir("./dist", resolve));
 
 export const deployFiles = () =>
     gulp.src(sources.deployFiles).pipe(gulp.dest("./dist"));
@@ -31,18 +34,40 @@ export const css = () =>
         .pipe(gulp.dest("./dist/css"))
         .pipe(browserSync.stream());
 
-export const html = () => gulp.src(sources.html).pipe(gulp.dest("./dist"));
+// export const html = () => gulp.src(sources.html).pipe(gulp.dest("./dist"));
+export const html = () =>
+	exec('cp -r ' + sources.html + ' ./dist/', function (err, stdout, stderr) {
+		if (stdout) {
+			console.log(stdout);
+		}
+		if (stderr) {
+			console.log(stderr);
+		}
+	});
 
+/*
 export const assets = () =>
     gulp.src(sources.assets).pipe(gulp.dest("./dist/assets"));
+*/
+export const assets = () =>
+	exec('cp -r ' + sources.assets + ' ./dist/', function (err, stdout, stderr) {
+		if (stdout) {
+			console.log(stdout);
+		}
+		if (stderr) {
+			console.log(stderr);
+		}
+	});
 
 export const build = gulp.series(
     clean,
+    mkdir,
     gulp.parallel(js, css, html, assets, deployFiles)
 );
 
 export const devBuild = gulp.series(
     clean,
+    mkdir,
     gulp.parallel(bundleWithCacheForDevelopment, css, html, assets)
 );
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
         "build": "npm run build:aliases && npm run build:lambda && npm run build:app",
         "build:aliases": "cp html/edit.html html/COI.html && cp html/edit.html html/plan.html && cp html/event.html html/tag.html && cp html/event.html html/group.html",
         "build:app": "gulp build",
+        "devBuild": "gulp devBuild",
         "build:lambda": "netlify-lambda build src/lambda",
         "develop": "gulp develop",
         "lint": "eslint src",


### PR DESCRIPTION
It was taking a long time for gulp to build the html and the assets and gulp was simply piping everything in the html and assets folder. Defaulting to using `cp` instead of gulp pipes reduced the build time of the html stage from 48 secs to 46 ms and the assets stage from 53 secs to 2.79 ms.

Before: `gulp build`
```
Default:
[11:32:57] Requiring external module @babel/register
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
[11:32:57] Using gulpfile ~/git/districtr/gulpfile.babel.js
[11:32:57] Starting 'build'...
[11:32:57] Starting 'clean'...
[11:32:57] Finished 'clean' after 624 μs
[11:32:57] Starting 'js'...
[11:32:57] Starting 'css'...
[11:32:57] Starting 'html'...
[11:32:57] Starting 'assets'...
[11:32:57] Starting 'deployFiles'...
[11:32:57] Finished 'deployFiles' after 221 ms
[11:33:33] Finished 'css' after 36 s
[11:33:45] Finished 'html' after 48 s
[11:33:50] Finished 'assets' after 53 s
[11:33:53] Finished 'js' after 56 s
[11:33:53] Finished 'build' after 56 s
```
After:
```
[13:16:46] Requiring external module @babel/register
Browserslist: caniuse-lite is outdated. Please run:
npx browserslist@latest --update-db
[13:16:47] Using gulpfile ~/git/districtr/gulpfile.babel.js
[13:16:47] Starting 'build'...
[13:16:47] Starting 'clean'...
[13:16:47] Finished 'clean' after 2.07 ms
[13:16:47] Starting 'mkdir'...
[13:16:47] Finished 'mkdir' after 1.92 ms
[13:16:47] Starting 'js'...
[13:16:47] Starting 'css'...
[13:16:47] Starting 'html'...
[13:16:47] Starting 'assets'...
[13:16:47] Starting 'deployFiles'...
[13:16:47] Finished 'html' after 57 ms
[13:16:47] Finished 'deployFiles' after 158 ms
[13:16:50] Finished 'assets' after 2.75 s
[13:17:23] Finished 'css' after 36 s
[13:17:44] Finished 'js' after 56 s
[13:17:44] Finished 'build' after 56 s
```

Unfortunately, it looks like now the `js` stage of the build is the bottleneck. But, once that is resolved, build times will be cut to 36 seconds. It looks like `bundleView` is synchronous, so making `bundleView` asynchronous would probably help a lot.