### PR TITLE
create fort myeres module preview for qa only (don't merge)

### DIFF
--- a/assets/data/landing_pages.json
+++ b/assets/data/landing_pages.json
@@ -449,7 +449,7 @@
     "modules": [
       {"name": "Statewide", "ids": ["florida"], "id": "state", "default": "true"},
       {"name": "Counties", "ids": ["miamidade", "fl_hills", "fl_orange", "fl_osceola"], "id": "counties"},
-      {"name": "Cities", "ids": ["miamifl", "orlando", "tampa"], "id": "loc"}],
+      {"name": "Cities", "ids": ["miamifl", "orlando", "tampa", "fort_myers_fl"], "id": "loc"}],
     "sections": [
       {
         "name": "Draw a plan from scratch",

--- a/assets/data/modules/Florida.json
+++ b/assets/data/modules/Florida.json
@@ -2403,5 +2403,74 @@
         "pluralNoun": "Council Districts"
       }
     ]
+  },
+  {
+    "units": [
+      {
+        "id": "blocks",
+        "name": "Blocks",
+        "unitType": "Blocks",
+        "columnSets": [
+          {
+            "type": "population",
+            "name": "Population",
+            "total": {
+              "key": "TOTPOP",
+              "name": "Total population",
+              "sum": 1547,
+              "min": 1,
+              "max": 1
+            },
+            "subgroups": []
+          }
+        ],
+        "idColumn": {
+          "name": "Census GEOID",
+          "key": "GEOID10"
+        },
+        "nameColumn": {
+          "name": "Block Name",
+          "key": "NAME10"
+        },
+        "bounds": [
+          [
+            -81.9008,
+            26.5482
+          ],
+          [
+            -81.7508,
+            26.6795
+          ]
+        ],
+        "tilesets": [
+          {
+            "type": "fill",
+            "source": {
+              "type": "vector",
+              "url": "mapbox://districtr.fort_myers_fl_blocks"
+            },
+            "sourceLayer": "fort_myers_fl_blocks"
+          },
+          {
+            "type": "circle",
+            "source": {
+              "type": "vector",
+              "url": "mapbox://districtr.fort_myers_fl_blocks_points"
+            },
+            "sourceLayer": "fort_myers_fl_blocks_points"
+          }
+        ]
+      }
+    ],
+    "state": "Florida",
+    "name": "Fort Myers",
+    "id": "fort_myers_fl",
+    "districtingProblems": [
+      {
+        "name": "City Council",
+        "numberOfParts": 6,
+        "pluralNoun": "City Council Wards"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
About the data: module made out of 2010 census blocks with fort myers boundaries from our partners, population data is not mapped (totpop listed as one for each block) as this PR is meant for a preview of the module only, not to be merged

NOTE: This is just to provide a preview for our partners before the upcoming drop! Don't merge