### PR TITLE
Port /shp and /geojson exports to AWS lambda (cherry-picked)

### DIFF
--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -148,11 +148,11 @@ function exportPlanAsSHP(state, geojson) {
         },
         body: JSON.stringify(serialized),
     })
-    .then((res) => res.arrayBuffer())
-    .catch((e) => console.error(e))
-    .then((data) => {
-        download(`districtr-plan-${serialized.id}.${geojson ? "geojsons.zip" : "shp.zip"}`, data, true);
-    });
+        .then(shp => shp.arrayBuffer())
+        .catch(e => console.error(e))
+        .then(data => {
+            download(`districtr-plan-${serialized.id}.${geojson ? "geojson.zip" : "shp.zip"}`, data, true);
+        });
 }
 
 function exportPlanAsAssignmentFile(state, delimiter = ",", extension = "csv") {

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -135,18 +135,18 @@ function exportPlanAsJSON(state) {
 }
 function exportPlanAsSHP(state, geojson) {
     const serialized = state.serialize();
-    Object.keys(serialized.assignment).forEach((assign) => {
+    Object.keys(serialized.assignment).forEach(assign => {
         if (typeof serialized.assignment[assign] === 'number') {
             serialized.assignment[assign] = [serialized.assignment[assign]];
         }
     });
     render(renderModal(`Starting your ${geojson ? "GeoJSON" : "SHP"} download `), document.getElementById("modal"));
-    fetch("//mggg.pythonanywhere.com/" + (geojson ? "geojson" : "shp"), {
+    fetch("https://xi787ovfyb.execute-api.us-east-1.amazonaws.com/production/export/" + (geojson ? "geojson" : "shp"), {
         method: "POST",
         headers: {
-          "Content-Type": "application/json",
+          "Content-Type": "application/json"
         },
-        body: JSON.stringify(serialized),
+        body: JSON.stringify(serialized)
     })
         .then(shp => shp.arrayBuffer())
         .catch(e => console.error(e))

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -153,8 +153,9 @@ function exportPlanAsSHP(state, geojson, retry = 0) { // retry with backoff
     .then(response => {
         let status = response.status;
         if (status == 200) {
-            let data = response.arrayBuffer();
-            download(`districtr-plan-${serialized.id}.${geojson ? "geojson.zip" : "shp.zip"}`, data, true);
+            response.arrayBuffer().then(
+                data => download(`districtr-plan-${serialized.id}.${geojson ? "geojson.zip" : "shp.zip"}`, data, true)
+            );
         } else {
             console.error("Download failed; retrying . . .");
             throw 'Download failed'


### PR DESCRIPTION
This changes the endpoints. Note that the new AWS lambda endpoints returns a redirect to an S3 url with the file rather than the file itself as AWS Lambda can't return more than 13 MB in a response.