### PR TITLE
2020 vtd considerations

### DIFF
--- a/src/models/lib/assign.js
+++ b/src/models/lib/assign.js
@@ -27,6 +27,7 @@ export function assignUnitsAsTheyLoad(state, assignment, readyCallback) {
                 body: JSON.stringify({
                   id: state.place.id,
                   unitType: state.units.id,
+                  unitName: state.unitsRecord.id,
                   keyColumn: state.idColumn.key,
                   units: Array.from(populationUnloaded),
                 })
@@ -96,7 +97,7 @@ function assign(state, feature, partId, updateData) {
     if (updateData) {
         state.update(feature, partId);
     } else {
-        // don't update data; we sideloaded it already 
+        // don't update data; we sideloaded it already
     }
     partId.forEach((p) => {
         if (state.parts[p]) {

--- a/src/plugins/tools-plugin.js
+++ b/src/plugins/tools-plugin.js
@@ -251,11 +251,11 @@ function getMenuItems(state) {
             name: `Export Districtr-JSON`,
             onClick: () => exportPlanAsJSON(state)
         },
-        (spatial_abilities(state.place.id).shapefile ?  {
+        ((spatial_abilities(state.place.id).shapefile && !state.unitsRecord.id.includes("2020 VTD")) ?  {
             name: `Export${state.problem.type === "community" ? " COI " : " "}plan as SHP`,
             onClick: () => exportPlanAsSHP(state)
         } : null),
-        (spatial_abilities(state.place.id).shapefile ?  {
+        ((spatial_abilities(state.place.id).shapefile && !state.unitsRecord.id.includes("2020 VTD")) ?  {
             name: `Export${state.problem.type === "community" ? " COI " : " "}plan as GeoJSON`,
             onClick: () => exportPlanAsSHP(state, true)
         } : null),


### PR DESCRIPTION
These should be small but helpful
- don't show SHP / GeoJSON export options on 2020 VTDs. I've uploaded block groups to PA but we are still making a plan for VTDs
- include unitsRecord.id (blockgroups, blockgroups20) in post to /demographics, this is how I will determine 2020 block groups are being sent