### PR TITLE
Condenses and clarifies data source notification.

### DIFF
--- a/sass/components/_toolbar.scss
+++ b/sass/components/_toolbar.scss
@@ -17,8 +17,8 @@
     // 0 2px 4px rgba(0, 0, 0, 0.24);
     // box-shadow: -10px 0px 15px -20px rgba(0, 0, 0, 0.3);
     box-shadow: $raised;
-    width: 25%;
-    max-width: 350px;
+    width: 30%;
+    max-width: 32%;
     display: flex;
     flex-direction: column;
 }
@@ -34,7 +34,7 @@
   display: flex;
   padding: 0 1rem 1rem 1rem;
   font-size: 0.8rem;
-  text-align: justify;
+  text-align: left;
 }
 
 .dataset-info > p {
@@ -42,7 +42,7 @@
 }
 
 .dataset-info > span {
-  font-size: 0.6rem;
+  font-size: 0.55rem;
 }
 
 .district-row {

--- a/sass/components/_toolbar.scss
+++ b/sass/components/_toolbar.scss
@@ -17,7 +17,7 @@
     // 0 2px 4px rgba(0, 0, 0, 0.24);
     // box-shadow: -10px 0px 15px -20px rgba(0, 0, 0, 0.3);
     box-shadow: $raised;
-    width: 30%;
+    width: 28%;
     max-width: 32%;
     display: flex;
     flex-direction: column;
@@ -35,6 +35,10 @@
   padding: 0 1rem 1rem 1rem;
   font-size: 0.8rem;
   text-align: left;
+}
+
+.dataset-info {
+    padding-right: 0;
 }
 
 .dataset-info > p {

--- a/src/components/Charts/DatasetInfo.js
+++ b/src/components/Charts/DatasetInfo.js
@@ -11,29 +11,37 @@ function datasetInfo(state) {
     let population = state.population,
         place = state.place,
         populations = {
-            census: "Uses <strong>2010 Decennial Census</strong> data.",
-            census20: "Uses <strong>2020 Decennial Census</strong> data.",
-            acs: "Uses <strong>2019 American Community Survey</strong> data.",
-            mesa: "Uses <strong>2019 American Community Survey</strong> population disaggregated from blockgroups by Redistricting Partners.",
-            mesa2020: "Uses <strong>2020 Decennial Census</strong> population with processing by Redistricting Partners.",
-            pasorobles: "Uses <strong>2019 American Community Survey</strong> population disaggregated from blockgroups by Cooperative Strategies.",
-            sacramento: "Uses <strong>projected 2020 population</strong> based on the American Community Survey by National Demographics Corporation",
+            census: "Uses <strong>2010 Census</strong> data",
+            census20: "Uses <strong>2020 Census</strong> data",
+            acs: "Uses <strong>2019 American Community Survey</strong> data",
+            mesa: "Uses <strong>2019 American Community Survey</strong> population disaggregated from blockgroups by Redistricting Partners",
+            mesa2020: "Uses <strong>2020 Census</strong> population with processing by Redistricting Partners",
+            pasorobles: "Uses <strong>2019 American Community Survey</strong> population disaggregated from blockgroups by Cooperative Strategies",
+            sacramento: "Uses <strong>projected 2020 population</strong> based on the American Community Survey by National Demographics Corporation"
         },
-        acsLocations = ["wisco2019acs", "hall_ga", "grand_county_2", "mn2020acs", "nd_benson", "nd_dunn", "nd_mckenzie", "nd_mountrail", "nd_ramsey", "nd_rollette", "nd_sioux", "contracosta"];
+        acsLocations = [
+            "wisco2019acs", "hall_ga", "grand_county_2", "mn2020acs", "nd_benson",
+            "nd_dunn", "nd_mckenzie", "nd_mountrail", "nd_ramsey", "nd_rollette",
+            "nd_sioux", "contracosta"
+        ],
+        units = state.unitsRecord.name,
+        dataset = "";
+
     if (acsLocations.includes(place.id.toLowerCase()) || state.units.id.includes("2019") || population.name !== "Population") {
-        return `<p><span>&#9432;</span> ${populations.acs}</p>`;
+        dataset = `<p><span>&#9432;</span> ${populations.acs}`;
     } else if (["mesaaz", "sanluiso", "sanjoseca", "siskiyou", "redwood", "ca_ventura", "ca_yolo", "ca_solano", "ca_sc_county", "ca_sanmateo", "ca_kern", "ca_sanjoaquin", "ca_sc_county", "ca_tuolumne", "napa2021", "napacounty2021", "napa_boe", "santa_clara_h2o", "ca_oakland", "ca_martinez", "ca_humboldt", "carpinteria"].includes(place.id)) {
-        return `<p><span>&#9432;</span> ${populations.mesa}</p>`;
+        dataset = `<p><span>&#9432;</span> ${populations.mesa}`;
     } else if (["rp_lax", "ca_butte"].includes(place.id)) {
-        return `<p><span>&#9432;</span> ${populations.mesa2020}</p>`;
+        dataset = `<p><span>&#9432;</span> ${populations.mesa2020}`;
     } else if (["pasorobles"].includes(place.id)) {
-        return `<p><span>&#9432;</span> ${populations.pasorobles}</p>`;
+        dataset = `<p><span>&#9432;</span> ${populations.pasorobles}`;
     } else if (["sacramento", "ca_sonoma", "ca_pasadena", "ca_goleta", "ca_santabarbara", "ca_marin", "ca_kings", "ca_merced", "ca_fresno", "ca_nevada", "ca_marina", "ca_arroyo", "ca_sm_county", "ca_sanbenito", "ca_cvista", "ca_bellflower", "ca_camarillo", "ca_fresno_ci", "ca_fremont", "lake_el", "ca_chino", "ca_campbell", "ca_vallejo", "ca_oceano", "ca_grover", "ca_buellton", "buenapark", "ca_stockton", "halfmoon", "ca_carlsbad", "ca_richmond", "elcajon", "laverne", "encinitas", "lodi", "pomona", "sunnyvale"].includes(place.id)) {
-        return `<p><span>&#9432;</span> ${populations.sacramento}</p>`;
+        dataset = `<p><span>&#9432;</span> ${populations.sacramento}`;
     } else if (["2020 Block Groups", "2020 Blocks", "2020 Precincts", "2020 VTDs", "2020 Counties"].includes(state.unitsRecord.name)) {
-        return `<p><span>&#9432;</span> ${populations.census20}</p>`;
-    }
-    return `<p><span>&#9432;</span> ${populations.census}</p>`;
+        dataset = `<p><span>&#9432;</span> ${populations.census20}`;
+    } else dataset = `<p><span>&#9432;</span> ${populations.census}`;
+
+    return dataset + ` on <strong>${units}</strong>.</p>`;
 }
 
 /**

--- a/src/components/Charts/DatasetInfo.js
+++ b/src/components/Charts/DatasetInfo.js
@@ -11,11 +11,11 @@ function datasetInfo(state) {
     let population = state.population,
         place = state.place,
         populations = {
-            census: "Uses <strong>2010 Census</strong> data",
-            census20: "Uses <strong>2020 Census</strong> data",
+            census: "Uses <strong>2010 Decennial Census</strong> data",
+            census20: "Uses <strong>2020 Decennial Census</strong> data",
             acs: "Uses <strong>2019 American Community Survey</strong> data",
             mesa: "Uses <strong>2019 American Community Survey</strong> population disaggregated from blockgroups by Redistricting Partners",
-            mesa2020: "Uses <strong>2020 Census</strong> population with processing by Redistricting Partners",
+            mesa2020: "Uses <strong>2020 Decennial Census</strong> population with processing by Redistricting Partners",
             pasorobles: "Uses <strong>2019 American Community Survey</strong> population disaggregated from blockgroups by Cooperative Strategies",
             sacramento: "Uses <strong>projected 2020 population</strong> based on the American Community Survey by National Demographics Corporation"
         },

--- a/src/plugins/pop-balance-plugin.js
+++ b/src/plugins/pop-balance-plugin.js
@@ -70,10 +70,7 @@ export default function PopulationBalancePlugin(editor) {
             "Population Balance",
             () => html`
                 <section class="toolbar-inner dataset-info">
-                    ${populateDatasetInfo(state)};
-                </section>
-                <section class="toolbar-inner">
-                  <p><span>&#9432;</span> Units: <strong>${state.unitsRecord.name}</strong></p>
+                    ${populateDatasetInfo(state)}
                 </section>
                 ${MultiMemberPopBalanceChart(state.population, state.parts)}
                 <dl class="report-data-list">
@@ -88,10 +85,7 @@ export default function PopulationBalancePlugin(editor) {
             () =>
                 html`
                     <section class="toolbar-inner dataset-info">
-                        ${populateDatasetInfo(state)};
-                    </section>
-                    <section class="toolbar-inner">
-                      <p><span>&#9432;</span> Units: <strong>${state.unitsRecord.name}</strong></p>
+                        ${populateDatasetInfo(state)}
                     </section>
                     ${populationBarChart(state.population, state.activeParts)}
                     <dl class="report-data-list">


### PR DESCRIPTION
This takes the current text that notifies users of which data and units we're using:
<img width="319" alt="image" src="https://user-images.githubusercontent.com/9503402/131020599-ed39179b-00e1-44c5-8433-0458ccfb51a5.png">

and condenses each of the three most popular units (precincts, blocks, block groups) on a single line by slightly reducing the font size and slightly widening the tool pane width:
</br>

<img width="384" alt="image" src="https://user-images.githubusercontent.com/9503402/131163344-50140f33-b4c2-4453-b6b4-4f2a4e388bbf.png">