### PR TITLE
Ignore header when counting number of district IDs during CSV import

### DIFF
--- a/src/routes.js
+++ b/src/routes.js
@@ -231,7 +231,7 @@ export function loadPlanFromCSV(assignmentList, state) {
 
     const delimiter = (state.place.id === "louisiana") ? ";" : ",";
 
-    let districtIds = new Set(rows.map((row, index) => row.split(delimiter)[1].split("_")[0] ));
+    let districtIds = new Set(rows.slice(1).map((row, index) => row.split(delimiter)[1].split("_")[0] ));
     if (headers) {districtIds.delete(rows[0].split(delimiter)[1]);}
     districtIds.delete(undefined);
 


### PR DESCRIPTION
When importing from CSVs, districtr will override the default numberOfParts if the number of district labels exceeds the default. However, when importing CSVs with a header, the district label counting code will incorrectly count the header as a distinct district label. This leads to an unavoidable override of the default numberOfParts when importing a CSV with headers. 

This PR fixes the issue by ignoring the first row in the CSV, which should not affect headerless files since the default numberOfParts is usually correct and even if the user desires to override the default numberOfParts, there should be more than one precinct assigned to any given district.