### PR TITLE
add elections to 2020 VTD states

### DIFF
--- a/assets/data/modules/Alabama.json
+++ b/assets/data/modules/Alabama.json
@@ -671,6 +671,7 @@
          "id": "blockgroups20",
          "name": "2020 Block Groups",
          "unitType": "Block Groups",
+         "hideOnDefault": true,
          "columnSets": [
            {
              "type": "population",
@@ -843,7 +844,384 @@
              "sourceLayer": "al_20_blockgroups20"
            }
          ]
-       }
+      },
+      {
+        "id": "vtds20",
+        "name": "2020 VTDs",
+        "unitType": "VTDs",
+        "columnSets": [
+          {
+            "type": "election",
+            "name": "2016 Presidential",
+            "subgroups": [
+              {
+                "key": "G16PREDCLI",
+                "name": "Democratic",
+                "sum": 729631,
+                "min": 1,
+                "max": 4676
+              },
+              {
+                "key": "G16PRERTRU",
+                "name": "Republican",
+                "sum": 1318636,
+                "min": 0,
+                "max": 7790
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 US Senate",
+            "subgroups": [
+              {
+                "key": "G16USSDCRU",
+                "name": "Democratic",
+                "sum": 748775,
+                "min": 1,
+                "max": 4637
+              },
+              {
+                "key": "G16USSRSHE",
+                "name": "Republican",
+                "sum": 1335478,
+                "min": 0,
+                "max": 7842
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Governor",
+            "subgroups": [
+              {
+                "key": "G18GOVDMAD",
+                "name": "Democratic",
+                "sum": 694487,
+                "min": 1,
+                "max": 3795
+              },
+              {
+                "key": "G18GOVRIVE",
+                "name": "Republican",
+                "sum": 1022463,
+                "min": 0,
+                "max": 6224
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Lt. Governor",
+            "subgroups": [
+              {
+                "key": "G18LTGDBOY",
+                "name": "Democratic",
+                "sum": 660008,
+                "min": 0,
+                "max": 3819
+              },
+              {
+                "key": "G18LTGRAIN",
+                "name": "Republican",
+                "sum": 1044938,
+                "min": 0,
+                "max": 6414
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Attorney General",
+            "subgroups": [
+              {
+                "key": "G18ATGDSIE",
+                "name": "Democratic",
+                "sum": 702857,
+                "min": 1,
+                "max": 3852
+              },
+              {
+                "key": "G18ATGRMAR",
+                "name": "Republican",
+                "sum": 1004460,
+                "min": 0,
+                "max": 6097
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Secretary of State",
+            "subgroups": [
+              {
+                "key": "G18SOSDMIL",
+                "name": "Democratic",
+                "sum": 658533,
+                "min": 0,
+                "max": 3753
+              },
+              {
+                "key": "G18SOSRMER",
+                "name": "Republican",
+                "sum": 1032416,
+                "min": 0,
+                "max": 6257
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Auditor",
+            "subgroups": [
+              {
+                "key": "G18AUDDJOS",
+                "name": "Democratic",
+                "sum": 665701,
+                "min": 0,
+                "max": 3750
+              },
+              {
+                "key": "G18AUDRZEI",
+                "name": "Republican",
+                "sum": 1018455,
+                "min": 0,
+                "max": 6136
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Treasurer",
+            "subgroups": [
+              {
+                "key": "G18TREOWRI",
+                "name": "Other/write-in",
+                "sum": 31958,
+                "min": 0,
+                "max": 253
+              },
+              {
+                "key": "G18TRERMCM",
+                "name": "Republican",
+                "sum": 1085077,
+                "min": 0,
+                "max": 6513
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2020 Presidential",
+            "subgroups": [
+              {
+                "key": "G20PREDBID",
+                "name": "Democratic",
+                "sum": 849621,
+                "min": 0,
+                "max": 4950
+              },
+              {
+                "key": "G20PRERTRU",
+                "name": "Republican",
+                "sum": 1441157,
+                "min": 0,
+                "max": 8891
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2020 US Senate",
+            "subgroups": [
+              {
+                "key": "G20USSDJON",
+                "name": "Democratic",
+                "sum": 920485,
+                "min": 0,
+                "max": 5062
+              },
+              {
+                "key": "G20USSRTUB",
+                "name": "Republican",
+                "sum": 1392074,
+                "min": 0,
+                "max": 8507
+              }
+            ]
+          },
+          {
+            "type": "population",
+            "name": "Population",
+            "total": {
+              "key": "TOTPOP",
+              "name": "Total population",
+              "sum": 5024279,
+              "min": 6,
+              "max": 28753
+            },
+            "subgroups": [
+              {
+                "key": "WHITE",
+                "name": "White population",
+                "sum": 3171351,
+                "min": 0,
+                "max": 19599
+              },
+              {
+                "key": "BLACK",
+                "name": "Black population",
+                "sum": 1288159,
+                "min": 0,
+                "max": 10187
+              },
+              {
+                "key": "HISP",
+                "name": "Hispanic population",
+                "sum": 264047,
+                "min": 0,
+                "max": 7558
+              },
+              {
+                "key": "ASIAN",
+                "name": "Asian population",
+                "sum": 75918,
+                "min": 0,
+                "max": 2665
+              },
+              {
+                "key": "AMIN",
+                "name": "American Indian population",
+                "sum": 23119,
+                "min": 0,
+                "max": 1185
+              },
+              {
+                "key": "NHPI",
+                "name": "Native Hawaiian and Pacific Islander population",
+                "sum": 2612,
+                "min": 0,
+                "max": 99
+              },
+              {
+                "key": "2MORE",
+                "name": "Two or more races",
+                "sum": 184618,
+                "min": 0,
+                "max": 1332
+              },
+              {
+                "key": "OTHER",
+                "name": "Other races",
+                "sum": 14455,
+                "min": 0,
+                "max": 153
+              }
+            ]
+          },
+          {
+            "type": "population",
+            "name": "Voting Age Population",
+            "total": {
+              "key": "VAP",
+              "name": "Voting age population",
+              "sum": 3917166,
+              "min": 1,
+              "max": 22360
+            },
+            "subgroups": [
+              {
+                "key": "WVAP",
+                "name": "White voting age population",
+                "sum": 2564544,
+                "min": 0,
+                "max": 16062
+              },
+              {
+                "key": "BVAP",
+                "name": "Black voting age population",
+                "sum": 976732,
+                "min": 0,
+                "max": 7697
+              },
+              {
+                "key": "HVAP",
+                "name": "Hispanic voting age population",
+                "sum": 166856,
+                "min": 0,
+                "max": 4268
+              },
+              {
+                "key": "AMINVAP",
+                "name": "Native American voting age population",
+                "sum": 18137,
+                "min": 0,
+                "max": 860
+              },
+              {
+                "key": "NHPIVAP",
+                "name": "Native Hawaiian and Pacific Islander voting age population",
+                "sum": 1872,
+                "min": 0,
+                "max": 64
+              },
+              {
+                "key": "ASIANVAP",
+                "name": "Asian voting age population",
+                "sum": 59997,
+                "min": 0,
+                "max": 1896
+              },
+              {
+                "key": "OTHERVAP",
+                "name": "Other races voting age population",
+                "sum": 9084,
+                "min": 0,
+                "max": 149
+              },
+              {
+                "key": "2MOREVAP",
+                "name": "Two or more races voting age population",
+                "sum": 119944,
+                "min": 0,
+                "max": 814
+              }
+            ]
+          }
+        ],
+        "idColumn": {
+          "name": "VTD GEOID code",
+          "key": "GEOID20"
+        },
+        "bounds": [
+          [
+            -88.4732,
+            30.1444
+          ],
+          [
+            -84.8882,
+            35.008
+          ]
+        ],
+        "tilesets": [
+          {
+            "type": "fill",
+            "source": {
+              "type": "vector",
+              "url": "mapbox://districtr.al_vtds20"
+            },
+            "sourceLayer": "al_vtds20"
+          },
+          {
+            "type": "circle",
+            "source": {
+              "type": "vector",
+              "url": "mapbox://districtr.al_vtds20_points"
+            },
+            "sourceLayer": "al_vtds20_points"
+          }
+        ]
+      }
     ],
     "districtingProblems": [
       {

--- a/assets/data/modules/Arizona.json
+++ b/assets/data/modules/Arizona.json
@@ -1593,27 +1593,7 @@
         "columnSets": [
           {
             "type": "election",
-            "name": "2018 Governor",
-            "subgroups": [
-              {
-                "key": "GOV18D",
-                "name": "Democratic",
-                "sum": 994340,
-                "min": 0,
-                "max": 3735
-              },
-              {
-                "key": "GOV18R",
-                "name": "Republican",
-                "sum": 1330863,
-                "min": 0,
-                "max": 13570
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2018 Senate",
+            "name": "2018 US Senate",
             "subgroups": [
               {
                 "key": "SEN18D",
@@ -1628,6 +1608,26 @@
                 "sum": 1135200,
                 "min": 0,
                 "max": 12247
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 US House",
+            "subgroups": [
+              {
+                "key": "USH18D",
+                "name": "Democratic",
+                "sum": 1179193,
+                "min": 0,
+                "max": 4505
+              },
+              {
+                "key": "USH18R",
+                "name": "Republican",
+                "sum": 1139250,
+                "min": 0,
+                "max": 12657
               }
             ]
           },
@@ -1648,6 +1648,26 @@
                 "sum": 1201398,
                 "min": 0,
                 "max": 12702
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Governor",
+            "subgroups": [
+              {
+                "key": "GOV18D",
+                "name": "Democratic",
+                "sum": 994340,
+                "min": 0,
+                "max": 3735
+              },
+              {
+                "key": "GOV18R",
+                "name": "Republican",
+                "sum": 1330863,
+                "min": 0,
+                "max": 13570
               }
             ]
           },
@@ -1831,12 +1851,18 @@
           }
         ],
         "idColumn": {
-          "name": "2020 Census GEOID",
+          "name": "VTD GEOID code",
           "key": "GEOID20"
         },
         "bounds": [
-          [-114.8163, 31.3323],
-          [-109.0452, 37.0037]
+          [
+            -114.8163,
+            31.3323
+          ],
+          [
+            -109.0452,
+            37.0037
+          ]
         ],
         "tilesets": [
           {

--- a/assets/data/modules/Connecticut.json
+++ b/assets/data/modules/Connecticut.json
@@ -11,21 +11,41 @@
         "columnSets": [
           {
             "type": "election",
-            "name": "2018 Secretary of State",
+            "name": "2018 US Senate",
             "subgroups": [
               {
-                "key": "SOS18D",
+                "key": "SEN18D",
                 "name": "Democratic",
-                "sum": 735739,
+                "sum": 787693,
                 "min": 0,
-                "max": 3335
+                "max": 3602
               },
               {
-                "key": "SOS18R",
+                "key": "SEN18R",
                 "name": "Republican",
-                "sum": 557619,
+                "sum": 545721,
                 "min": 0,
-                "max": 3986
+                "max": 3953
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 US House",
+            "subgroups": [
+              {
+                "key": "USH18D",
+                "name": "Democratic",
+                "sum": 808658,
+                "min": 0,
+                "max": 3607
+              },
+              {
+                "key": "USH18R",
+                "name": "Republican",
+                "sum": 512497,
+                "min": 0,
+                "max": 3935
               }
             ]
           },
@@ -36,36 +56,16 @@
               {
                 "key": "AG18D",
                 "name": "Democratic",
-                "sum": 691495,
+                "sum": 691490,
                 "min": 0,
                 "max": 3228
               },
               {
                 "key": "AG18R",
                 "name": "Republican",
-                "sum": 605509,
+                "sum": 605497,
                 "min": 0,
-                "max": 4272
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2018 Senate",
-            "subgroups": [
-              {
-                "key": "SEN18D",
-                "name": "Democratic",
-                "sum": 787683,
-                "min": 0,
-                "max": 3600
-              },
-              {
-                "key": "SEN18R",
-                "name": "Republican",
-                "sum": 545721,
-                "min": 0,
-                "max": 3942
+                "max": 4284
               }
             ]
           },
@@ -76,16 +76,36 @@
               {
                 "key": "GOV18D",
                 "name": "Democratic",
-                "sum": 676656,
+                "sum": 676642,
                 "min": 0,
                 "max": 3248
               },
               {
                 "key": "GOV18R",
                 "name": "Republican",
-                "sum": 624747,
+                "sum": 624751,
                 "min": 0,
-                "max": 4467
+                "max": 4479
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Secretary of State",
+            "subgroups": [
+              {
+                "key": "SOS18D",
+                "name": "Democratic",
+                "sum": 735749,
+                "min": 0,
+                "max": 3337
+              },
+              {
+                "key": "SOS18R",
+                "name": "Republican",
+                "sum": 557627,
+                "min": 0,
+                "max": 3997
               }
             ]
           },
@@ -96,16 +116,36 @@
               {
                 "key": "TRE18D",
                 "name": "Democratic",
-                "sum": 717000,
+                "sum": 716991,
                 "min": 0,
-                "max": 3250
+                "max": 3252
               },
               {
                 "key": "TRE18R",
                 "name": "Republican",
-                "sum": 569736,
+                "sum": 569732,
                 "min": 0,
-                "max": 4019
+                "max": 4031
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Comptroller",
+            "subgroups": [
+              {
+                "key": "COMP18D",
+                "name": "Democratic",
+                "sum": 718034,
+                "min": 0,
+                "max": 3298
+              },
+              {
+                "key": "COMP18R",
+                "name": "Republican",
+                "sum": 563106,
+                "min": 0,
+                "max": 4174
               }
             ]
           },
@@ -253,8 +293,14 @@
           "key": "GEOID20"
         },
         "bounds": [
-          [-73.7278, 40.9509],
-          [-71.7872, 42.0505]
+          [
+            -73.7278,
+            40.9509
+          ],
+          [
+            -71.7872,
+            42.0505
+          ]
         ],
         "tilesets": [
           {

--- a/assets/data/modules/Delaware.json
+++ b/assets/data/modules/Delaware.json
@@ -9,261 +9,21 @@
         "columnSets": [
           {
             "type": "election",
-            "name": "2012 President",
-            "subgroups": [
-              {
-                "key": "PRES12D",
-                "name": "Democratic",
-                "sum": 242584,
-                "min": 0,
-                "max": 1702
-              },
-              {
-                "key": "PRES12R",
-                "name": "Republican",
-                "sum": 165430,
-                "min": 0,
-                "max": 1535
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2012 Senate",
-            "subgroups": [
-              {
-                "key": "SEN12D",
-                "name": "Democratic",
-                "sum": 265419,
-                "min": 0,
-                "max": 1834
-              },
-              {
-                "key": "SEN12R",
-                "name": "Republican",
-                "sum": 115654,
-                "min": 0,
-                "max": 1130
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2012 US House",
-            "subgroups": [
-              {
-                "key": "USH12D",
-                "name": "Democratic",
-                "sum": 249934,
-                "min": 0,
-                "max": 1721
-              },
-              {
-                "key": "USH12R",
-                "name": "Republican",
-                "sum": 129706,
-                "min": 0,
-                "max": 1193
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2012 Governor",
-            "subgroups": [
-              {
-                "key": "GOV12D",
-                "name": "Democratic",
-                "sum": 275989,
-                "min": 0,
-                "max": 1872
-              },
-              {
-                "key": "GOV12R",
-                "name": "Republican",
-                "sum": 113786,
-                "min": 0,
-                "max": 1148
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2014 Senate",
-            "subgroups": [
-              {
-                "key": "SEN14D",
-                "name": "Democratic",
-                "sum": 130585,
-                "min": 0,
-                "max": 1036
-              },
-              {
-                "key": "SEN14R",
-                "name": "Republican",
-                "sum": 98810,
-                "min": 0,
-                "max": 986
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2014 US House",
-            "subgroups": [
-              {
-                "key": "USH14D",
-                "name": "Democratic",
-                "sum": 137181,
-                "min": 0,
-                "max": 1123
-              },
-              {
-                "key": "USH14R",
-                "name": "Republican",
-                "sum": 85136,
-                "min": 0,
-                "max": 854
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2014 Attorney General",
-            "subgroups": [
-              {
-                "key": "AG14D",
-                "name": "Democratic",
-                "sum": 121405,
-                "min": 0,
-                "max": 962
-              },
-              {
-                "key": "AG14R",
-                "name": "Republican",
-                "sum": 90257,
-                "min": 0,
-                "max": 906
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2014 Treasurer",
-            "subgroups": [
-              {
-                "key": "TRE14D",
-                "name": "Democratic",
-                "sum": 100222,
-                "min": 0,
-                "max": 750
-              },
-              {
-                "key": "TRE14R",
-                "name": "Republican",
-                "sum": 123104,
-                "min": 0,
-                "max": 1267
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2014 Auditor",
-            "subgroups": [
-              {
-                "key": "AUD14D",
-                "name": "Democratic",
-                "sum": 103941,
-                "min": 0,
-                "max": 805
-              },
-              {
-                "key": "AUD14R",
-                "name": "Republican",
-                "sum": 123102,
-                "min": 0,
-                "max": 1135
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2016 President",
-            "subgroups": [
-              {
-                "key": "PRES16D",
-                "name": "Democratic",
-                "sum": 235614,
-                "min": 0,
-                "max": 1769
-              },
-              {
-                "key": "PRES16R",
-                "name": "Republican",
-                "sum": 185067,
-                "min": 0,
-                "max": 1861
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2016 US House",
-            "subgroups": [
-              {
-                "key": "USH16D",
-                "name": "Democratic",
-                "sum": 233545,
-                "min": 0,
-                "max": 1732
-              },
-              {
-                "key": "USH16R",
-                "name": "Republican",
-                "sum": 172240,
-                "min": 0,
-                "max": 1679
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2016 Governor",
-            "subgroups": [
-              {
-                "key": "GOV16D",
-                "name": "Democratic",
-                "sum": 248321,
-                "min": 0,
-                "max": 1907
-              },
-              {
-                "key": "GOV16R",
-                "name": "Republican",
-                "sum": 166833,
-                "min": 0,
-                "max": 1601
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2018 Senate",
+            "name": "2018 US Senate",
             "subgroups": [
               {
                 "key": "SEN18D",
                 "name": "Democratic",
-                "sum": 217388,
+                "sum": 217386,
                 "min": 0,
-                "max": 1913
+                "max": 2200
               },
               {
                 "key": "SEN18R",
                 "name": "Republican",
-                "sum": 137102,
+                "sum": 137105,
                 "min": 0,
-                "max": 1386
+                "max": 1836
               }
             ]
           },
@@ -274,16 +34,16 @@
               {
                 "key": "USH18D",
                 "name": "Democratic",
-                "sum": 227353,
+                "sum": 227358,
                 "min": 0,
-                "max": 1969
+                "max": 2291
               },
               {
                 "key": "USH18R",
                 "name": "Republican",
-                "sum": 125363,
+                "sum": 125368,
                 "min": 0,
-                "max": 1289
+                "max": 1705
               }
             ]
           },
@@ -294,16 +54,56 @@
               {
                 "key": "AG18D",
                 "name": "Democratic",
-                "sum": 218348,
+                "sum": 218356,
                 "min": 0,
-                "max": 1961
+                "max": 2175
               },
               {
                 "key": "AG18R",
                 "name": "Republican",
-                "sum": 137728,
+                "sum": 137726,
                 "min": 0,
-                "max": 1352
+                "max": 1880
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 State Auditor",
+            "subgroups": [
+              {
+                "key": "AUD18D",
+                "name": "Democratic",
+                "sum": 205623,
+                "min": 0,
+                "max": 2111
+              },
+              {
+                "key": "AUD18R",
+                "name": "Republican",
+                "sum": 149479,
+                "min": 0,
+                "max": 1926
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 State House",
+            "subgroups": [
+              {
+                "key": "SH18D",
+                "name": "Democratic",
+                "sum": 199723,
+                "min": 0,
+                "max": 2100
+              },
+              {
+                "key": "SH18R",
+                "name": "Republican",
+                "sum": 135694,
+                "min": 0,
+                "max": 2058
               }
             ]
           },
@@ -314,36 +114,336 @@
               {
                 "key": "TRE18D",
                 "name": "Democratic",
-                "sum": 187240,
+                "sum": 187237,
                 "min": 0,
-                "max": 1547
+                "max": 1938
               },
               {
                 "key": "TRE18R",
                 "name": "Republican",
-                "sum": 163998,
+                "sum": 164002,
                 "min": 0,
-                "max": 1706
+                "max": 2060
               }
             ]
           },
           {
             "type": "election",
-            "name": "2018 Auditor",
+            "name": "2016 State House",
             "subgroups": [
               {
-                "key": "AUD18D",
+                "key": "SH16D",
                 "name": "Democratic",
-                "sum": 205623,
+                "sum": 226084,
                 "min": 0,
-                "max": 1864
+                "max": 2630
               },
               {
-                "key": "AUD18R",
+                "key": "SH16R",
                 "name": "Republican",
-                "sum": 149479,
+                "sum": 149872,
                 "min": 0,
-                "max": 1413
+                "max": 2379
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 Governor",
+            "subgroups": [
+              {
+                "key": "GOV16D",
+                "name": "Democratic",
+                "sum": 248312,
+                "min": 0,
+                "max": 2471
+              },
+              {
+                "key": "GOV16R",
+                "name": "Republican",
+                "sum": 166838,
+                "min": 0,
+                "max": 2131
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 US House",
+            "subgroups": [
+              {
+                "key": "USH16D",
+                "name": "Democratic",
+                "sum": 233541,
+                "min": 0,
+                "max": 2168
+              },
+              {
+                "key": "USH16R",
+                "name": "Republican",
+                "sum": 172241,
+                "min": 0,
+                "max": 2266
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 Presidential",
+            "subgroups": [
+              {
+                "key": "PRES16D",
+                "name": "Democratic",
+                "sum": 235617,
+                "min": 0,
+                "max": 2120
+              },
+              {
+                "key": "PRES16R",
+                "name": "Republican",
+                "sum": 185064,
+                "min": 0,
+                "max": 2504
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 State House",
+            "subgroups": [
+              {
+                "key": "SH14D",
+                "name": "Democratic",
+                "sum": 116353,
+                "min": 0,
+                "max": 1222
+              },
+              {
+                "key": "SH14R",
+                "name": "Republican",
+                "sum": 91576,
+                "min": 0,
+                "max": 1264
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 US House",
+            "subgroups": [
+              {
+                "key": "USH14D",
+                "name": "Democratic",
+                "sum": 137182,
+                "min": 0,
+                "max": 1291
+              },
+              {
+                "key": "USH14R",
+                "name": "Republican",
+                "sum": 85138,
+                "min": 0,
+                "max": 933
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 State Auditor",
+            "subgroups": [
+              {
+                "key": "AUD14D",
+                "name": "Democratic",
+                "sum": 103942,
+                "min": 0,
+                "max": 937
+              },
+              {
+                "key": "AUD14R",
+                "name": "Republican",
+                "sum": 123101,
+                "min": 0,
+                "max": 1348
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 Treasurer",
+            "subgroups": [
+              {
+                "key": "TRE14D",
+                "name": "Democratic",
+                "sum": 100223,
+                "min": 0,
+                "max": 956
+              },
+              {
+                "key": "TRE14R",
+                "name": "Republican",
+                "sum": 123103,
+                "min": 0,
+                "max": 1283
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 Attorney General",
+            "subgroups": [
+              {
+                "key": "AG14D",
+                "name": "Democratic",
+                "sum": 121406,
+                "min": 0,
+                "max": 1158
+              },
+              {
+                "key": "AG14R",
+                "name": "Republican",
+                "sum": 90262,
+                "min": 0,
+                "max": 964
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 US Senate",
+            "subgroups": [
+              {
+                "key": "SEN14D",
+                "name": "Democratic",
+                "sum": 130586,
+                "min": 0,
+                "max": 1213
+              },
+              {
+                "key": "SEN14R",
+                "name": "Republican",
+                "sum": 98816,
+                "min": 0,
+                "max": 1077
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 State House",
+            "subgroups": [
+              {
+                "key": "SH12D",
+                "name": "Democratic",
+                "sum": 226719,
+                "min": 0,
+                "max": 2034
+              },
+              {
+                "key": "SH12R",
+                "name": "Republican",
+                "sum": 124810,
+                "min": 0,
+                "max": 1776
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 State Senate",
+            "subgroups": [
+              {
+                "key": "SSEN12D",
+                "name": "Democratic",
+                "sum": 234612,
+                "min": 0,
+                "max": 2182
+              },
+              {
+                "key": "SSEN12R",
+                "name": "Republican",
+                "sum": 123378,
+                "min": 0,
+                "max": 3119
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 Governor",
+            "subgroups": [
+              {
+                "key": "GOV12D",
+                "name": "Democratic",
+                "sum": 275993,
+                "min": 0,
+                "max": 2478
+              },
+              {
+                "key": "GOV12R",
+                "name": "Republican",
+                "sum": 113791,
+                "min": 0,
+                "max": 1341
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 US House",
+            "subgroups": [
+              {
+                "key": "USH12D",
+                "name": "Democratic",
+                "sum": 249933,
+                "min": 0,
+                "max": 2345
+              },
+              {
+                "key": "USH12R",
+                "name": "Republican",
+                "sum": 129703,
+                "min": 0,
+                "max": 1335
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 US Senate",
+            "subgroups": [
+              {
+                "key": "SEN12D",
+                "name": "Democratic",
+                "sum": 265420,
+                "min": 0,
+                "max": 2487
+              },
+              {
+                "key": "SEN12R",
+                "name": "Republican",
+                "sum": 115656,
+                "min": 0,
+                "max": 1241
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 Presidential",
+            "subgroups": [
+              {
+                "key": "PRES12D",
+                "name": "Democratic",
+                "sum": 242587,
+                "min": 0,
+                "max": 2100
+              },
+              {
+                "key": "PRES12R",
+                "name": "Republican",
+                "sum": 165430,
+                "min": 0,
+                "max": 1888
               }
             ]
           },
@@ -491,8 +591,14 @@
           "key": "GEOID20"
         },
         "bounds": [
-          [-75.789, 38.4511],
-          [-74.9842, 39.8395]
+          [
+            -75.789,
+            38.4511
+          ],
+          [
+            -74.9842,
+            39.8395
+          ]
         ],
         "tilesets": [
           {

--- a/assets/data/modules/Indiana.json
+++ b/assets/data/modules/Indiana.json
@@ -575,27 +575,7 @@
           },
           {
             "type": "election",
-            "name": "2016 Governor",
-            "subgroups": [
-              {
-                "key": "GOV16D",
-                "name": "Democratic",
-                "sum": 1233661,
-                "min": 0,
-                "max": 935
-              },
-              {
-                "key": "GOV16R",
-                "name": "Republican",
-                "sum": 1386597,
-                "min": 0,
-                "max": 1611
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2016 Senate",
+            "name": "2016 US Senate",
             "subgroups": [
               {
                 "key": "SEN16D",
@@ -630,6 +610,166 @@
                 "sum": 1644132,
                 "min": 0,
                 "max": 1672
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 Governor",
+            "subgroups": [
+              {
+                "key": "GOV16D",
+                "name": "Democratic",
+                "sum": 1233661,
+                "min": 0,
+                "max": 935
+              },
+              {
+                "key": "GOV16R",
+                "name": "Republican",
+                "sum": 1386597,
+                "min": 0,
+                "max": 1611
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 US Senate",
+            "subgroups": [
+              {
+                "key": "G18USSDDON",
+                "name": "Democratic",
+                "sum": 1023798,
+                "min": 0,
+                "max": 874
+              },
+              {
+                "key": "G18USSRBRA",
+                "name": "Republican",
+                "sum": 1158690,
+                "min": 0,
+                "max": 1430
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Secretary of State",
+            "subgroups": [
+              {
+                "key": "G18SOSDHAR",
+                "name": "Democratic",
+                "sum": 911788,
+                "min": 0,
+                "max": 851
+              },
+              {
+                "key": "G18SOSRLAW",
+                "name": "Republican",
+                "sum": 1263751,
+                "min": 0,
+                "max": 1456
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Auditor",
+            "subgroups": [
+              {
+                "key": "G18AUDDWHI",
+                "name": "Democratic",
+                "sum": 913942,
+                "min": 0,
+                "max": 842
+              },
+              {
+                "key": "G18AUDRKLU",
+                "name": "Republican",
+                "sum": 1236266,
+                "min": 0,
+                "max": 1442
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Treasurer",
+            "subgroups": [
+              {
+                "key": "G18TREDAGU",
+                "name": "Democratic",
+                "sum": 919819,
+                "min": 0,
+                "max": 855
+              },
+              {
+                "key": "G18TRERMIT",
+                "name": "Republican",
+                "sum": 1301642,
+                "min": 0,
+                "max": 1490
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2020 Presidential",
+            "subgroups": [
+              {
+                "key": "G20PREDBID",
+                "name": "Democratic",
+                "sum": 1242498,
+                "min": 0,
+                "max": 1391
+              },
+              {
+                "key": "G20PRERTRU",
+                "name": "Republican",
+                "sum": 1729859,
+                "min": 0,
+                "max": 2062
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2020 Governor",
+            "subgroups": [
+              {
+                "key": "G20GOVDMYE",
+                "name": "Democratic",
+                "sum": 968097,
+                "min": 0,
+                "max": 1087
+              },
+              {
+                "key": "G20GOVRHOL",
+                "name": "Republican",
+                "sum": 1706727,
+                "min": 0,
+                "max": 2072
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2020 Attorney General",
+            "subgroups": [
+              {
+                "key": "G20ATGDWEI",
+                "name": "Democratic",
+                "sum": 1229632,
+                "min": 0,
+                "max": 1301
+              },
+              {
+                "key": "G20ATGRROK",
+                "name": "Republican",
+                "sum": 1721983,
+                "min": 0,
+                "max": 2038
               }
             ]
           },
@@ -791,17 +931,17 @@
             "type": "fill",
             "source": {
               "type": "vector",
-              "url": "mapbox://districtr.in_vtds20"
+              "url": "mapbox://districtr.indiana_vtds20"
             },
-            "sourceLayer": "in_vtds20"
+            "sourceLayer": "indiana_vtds20"
           },
           {
             "type": "circle",
             "source": {
               "type": "vector",
-              "url": "mapbox://districtr.in_vtds20_points"
+              "url": "mapbox://districtr.indiana_vtds20_points"
             },
-            "sourceLayer": "in_vtds20_points"
+            "sourceLayer": "indiana_vtds20_points"
           }
         ]
       },

--- a/assets/data/modules/Louisiana.json
+++ b/assets/data/modules/Louisiana.json
@@ -16,16 +16,16 @@
               {
                 "key": "GOV15D",
                 "name": "Democratic",
-                "sum": 646073,
+                "sum": 646080,
                 "min": 0,
-                "max": 1001
+                "max": 1132
               },
               {
                 "key": "GOV15R",
                 "name": "Republican",
-                "sum": 505695,
+                "sum": 505697,
                 "min": 0,
-                "max": 960
+                "max": 762
               }
             ]
           },
@@ -36,56 +36,83 @@
               {
                 "key": "SOS15D",
                 "name": "Democratic",
-                "sum": 393926,
+                "sum": 393937,
                 "min": 0,
-                "max": 717
+                "max": 826
               },
               {
                 "key": "SOS15R",
                 "name": "Republican",
-                "sum": 649227,
+                "sum": 649209,
                 "min": 0,
-                "max": 1155
+                "max": 1022
               }
             ]
           },
           {
             "type": "election",
-            "name": "2016 President",
+            "name": "2016 Presidential",
             "subgroups": [
               {
                 "key": "PRES16D",
                 "name": "Democratic",
-                "sum": 778870,
+                "sum": 778882,
                 "min": 0,
-                "max": 1484
+                "max": 1456
               },
               {
                 "key": "PRES16R",
                 "name": "Republican",
-                "sum": 1177983,
+                "sum": 1177979,
                 "min": 0,
-                "max": 1784
+                "max": 1726
               }
             ]
           },
           {
             "type": "election",
-            "name": "2016 Senate Runoff",
+            "name": "2016 US Senate Runoff",
             "subgroups": [
               {
                 "key": "SEN16roD",
                 "name": "Democratic",
-                "sum": 346959,
+                "sum": 346977,
                 "min": 0,
-                "max": 780
+                "max": 862
               },
               {
                 "key": "SEN16roR",
                 "name": "Republican",
-                "sum": 535751,
+                "sum": 535752,
                 "min": 0,
-                "max": 1023
+                "max": 1068
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 Dem. Presidential Primary",
+            "subgroups": [
+              {
+                "key": "PRES16pD2",
+                "name": "Clinton",
+                "sum": 221324,
+                "min": 0,
+                "max": 669
+              },
+              {
+                "key": "PRES16pD6",
+                "name": "O'Malley",
+                "sum": 2091,
+                "min": 0,
+                "max": 10
+              },
+              {
+                "key": "PRES16pD7",
+                "name": "Sanders",
+                "sum": 72179,
+                "min": 0,
+                "max": 135
               }
             ]
           },
@@ -96,96 +123,36 @@
               {
                 "key": "TRE17D",
                 "name": "Democratic",
-                "sum": 165071,
+                "sum": 165076,
                 "min": 0,
                 "max": 607
               },
               {
                 "key": "TRE17R",
                 "name": "Republican",
-                "sum": 208009,
+                "sum": 207992,
                 "min": 0,
-                "max": 454
+                "max": 504
               }
             ]
           },
           {
             "type": "election",
-            "name": "2018 Secretary of State",
+            "name": "2018 Secretary of State Special",
             "subgroups": [
               {
                 "key": "SOS18D",
                 "name": "Democratic",
                 "sum": 209596,
                 "min": 0,
-                "max": 592
+                "max": 744
               },
               {
                 "key": "SOS18R",
                 "name": "Republican",
-                "sum": 306309,
+                "sum": 306291,
                 "min": 0,
-                "max": 800
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2019 Governor",
-            "subgroups": [
-              {
-                "key": "GOV19D",
-                "name": "Democratic",
-                "sum": 774495,
-                "min": 0,
-                "max": 1634
-              },
-              {
-                "key": "GOV19R",
-                "name": "Republican",
-                "sum": 734282,
-                "min": 0,
-                "max": 1300
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2016 Treasurer",
-            "subgroups": [
-              {
-                "key": "TRE19pD",
-                "name": "Democratic",
-                "sum": 442745,
-                "min": 0,
-                "max": 944
-              },
-              {
-                "key": "TRE19pR",
-                "name": "Republican",
-                "sum": 769477,
-                "min": 0,
-                "max": 1378
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2019 Secretary of State",
-            "subgroups": [
-              {
-                "key": "SOS19D",
-                "name": "Democratic",
-                "sum": 601131,
-                "min": 0,
-                "max": 1264
-              },
-              {
-                "key": "SOS19R",
-                "name": "Republican",
-                "sum": 867610,
-                "min": 0,
-                "max": 1567
+                "max": 860
               }
             ]
           },
@@ -196,16 +163,96 @@
               {
                 "key": "AG19D",
                 "name": "Democratic",
-                "sum": 436511,
+                "sum": 436489,
                 "min": 0,
-                "max": 984
+                "max": 862
               },
               {
                 "key": "AG19R",
                 "name": "Republican",
-                "sum": 855353,
+                "sum": 855335,
                 "min": 0,
-                "max": 1474
+                "max": 1450
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2019 Governor",
+            "subgroups": [
+              {
+                "key": "GOV19D",
+                "name": "Democratic",
+                "sum": 774500,
+                "min": 0,
+                "max": 1279
+              },
+              {
+                "key": "GOV19R",
+                "name": "Republican",
+                "sum": 734282,
+                "min": 0,
+                "max": 1223
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2019 Treasurer",
+            "subgroups": [
+              {
+                "key": "TRE19pD",
+                "name": "Democratic",
+                "sum": 442742,
+                "min": 0,
+                "max": 940
+              },
+              {
+                "key": "TRE19pR",
+                "name": "Republican",
+                "sum": 769469,
+                "min": 0,
+                "max": 1272
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2019 Secretary of State",
+            "subgroups": [
+              {
+                "key": "SOS19D",
+                "name": "Democratic",
+                "sum": 601116,
+                "min": 0,
+                "max": 1169
+              },
+              {
+                "key": "SOS19R",
+                "name": "Republican",
+                "sum": 867607,
+                "min": 0,
+                "max": 1318
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2019 Lt. Governor",
+            "subgroups": [
+              {
+                "key": "LG19D",
+                "name": "Democratic",
+                "sum": 413567,
+                "min": 0,
+                "max": 863
+              },
+              {
+                "key": "LG19R",
+                "name": "Republican",
+                "sum": 884296,
+                "min": 0,
+                "max": 1423
               }
             ]
           },
@@ -349,12 +396,18 @@
           }
         ],
         "idColumn": {
-          "name": "2020 Census GEOID",
+          "name": "VTD GEOID code",
           "key": "GEOID20"
         },
         "bounds": [
-          [-94.0434, 28.8551],
-          [-88.7584, 33.0196]
+          [
+            -94.0434,
+            28.8551
+          ],
+          [
+            -88.7584,
+            33.0196
+          ]
         ],
         "tilesets": [
           {

--- a/assets/data/modules/Massachusetts.json
+++ b/assets/data/modules/Massachusetts.json
@@ -2104,19 +2104,119 @@
         "columnSets": [
           {
             "type": "election",
+            "name": "2012 US Senate",
+            "subgroups": [
+              {
+                "key": "SEN12GEWAR",
+                "name": "Democratic",
+                "sum": 1696347,
+                "min": 0,
+                "max": 3435
+              },
+              {
+                "key": "SEN12GSBRO",
+                "name": "Republican",
+                "sum": 1458055,
+                "min": 0,
+                "max": 2653
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 Presidential",
+            "subgroups": [
+              {
+                "key": "PRES12GBOB",
+                "name": "Democratic",
+                "sum": 1921290,
+                "min": 0,
+                "max": 3830
+              },
+              {
+                "key": "PRES12GMRO",
+                "name": "Republican",
+                "sum": 1188313,
+                "min": 0,
+                "max": 2280
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2013 US Senate Special",
+            "subgroups": [
+              {
+                "key": "SEN13GEMAR",
+                "name": "Democratic",
+                "sum": 645433,
+                "min": 0,
+                "max": 1219
+              },
+              {
+                "key": "SEN13GGGOM",
+                "name": "Republican",
+                "sum": 525304,
+                "min": 0,
+                "max": 1403
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 US Senate",
+            "subgroups": [
+              {
+                "key": "SEN14GEMAR",
+                "name": "Democratic",
+                "sum": 1289944,
+                "min": 0,
+                "max": 2233
+              },
+              {
+                "key": "SEN14GHERR",
+                "name": "Republican",
+                "sum": 791954,
+                "min": 0,
+                "max": 1760
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 Presidential",
+            "subgroups": [
+              {
+                "key": "PRES16GHCL",
+                "name": "Democratic",
+                "sum": 1995200,
+                "min": 0,
+                "max": 4146
+              },
+              {
+                "key": "PRES16GDTR",
+                "name": "Republican",
+                "sum": 1090890,
+                "min": 0,
+                "max": 1892
+              }
+            ]
+          },
+          {
+            "type": "election",
             "name": "2014 Governor",
             "subgroups": [
               {
                 "key": "GOV14D",
                 "name": "Democratic",
-                "sum": 1004413,
+                "sum": 1004416,
                 "min": 0,
                 "max": 1817
               },
               {
                 "key": "GOV14R",
                 "name": "Republican",
-                "sum": 1044571,
+                "sum": 1044569,
                 "min": 0,
                 "max": 2063
               }
@@ -2144,21 +2244,181 @@
           },
           {
             "type": "election",
-            "name": "2018 Senate",
+            "name": "2018 US Senate",
             "subgroups": [
               {
                 "key": "SEN18D",
                 "name": "Democratic",
-                "sum": 1633371,
+                "sum": 1633369,
                 "min": 0,
                 "max": 2662
               },
               {
                 "key": "SEN18R",
                 "name": "Republican",
-                "sum": 979212,
+                "sum": 979213,
                 "min": 0,
                 "max": 1862
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 Attorney General",
+            "subgroups": [
+              {
+                "key": "AG14GMHEAL",
+                "name": "Democratic",
+                "sum": 1280513,
+                "min": 0,
+                "max": 2099
+              },
+              {
+                "key": "AG14GJMILL",
+                "name": "Republican",
+                "sum": 793823,
+                "min": 0,
+                "max": 1773
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 Treasurer",
+            "subgroups": [
+              {
+                "key": "TRE14GDGOL",
+                "name": "Democratic",
+                "sum": 1120194,
+                "min": 0,
+                "max": 1905
+              },
+              {
+                "key": "TRE14GMHEF",
+                "name": "Republican",
+                "sum": 828896,
+                "min": 0,
+                "max": 1848
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 State Auditor",
+            "subgroups": [
+              {
+                "key": "AUD14GPBUM",
+                "name": "Democratic",
+                "sum": 1146985,
+                "min": 0,
+                "max": 1976
+              },
+              {
+                "key": "AUD14GSSAI",
+                "name": "Republican",
+                "sum": 757219,
+                "min": 0,
+                "max": 1775
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Attorney General",
+            "subgroups": [
+              {
+                "key": "AG18GMHEAL",
+                "name": "Democratic",
+                "sum": 1874212,
+                "min": 0,
+                "max": 2928
+              },
+              {
+                "key": "AG18GJMCMA",
+                "name": "Republican",
+                "sum": 804831,
+                "min": 0,
+                "max": 1621
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Treasurer",
+            "subgroups": [
+              {
+                "key": "TRE18GDGOL",
+                "name": "Democratic",
+                "sum": 1761283,
+                "min": 0,
+                "max": 2803
+              },
+              {
+                "key": "TRE18GKORR",
+                "name": "Republican",
+                "sum": 749596,
+                "min": 0,
+                "max": 1600
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 State Auditor",
+            "subgroups": [
+              {
+                "key": "AUD18GSBUM",
+                "name": "Democratic",
+                "sum": 1606512,
+                "min": 0,
+                "max": 2635
+              },
+              {
+                "key": "AUD18GHBRA",
+                "name": "Republican",
+                "sum": 801585,
+                "min": 0,
+                "max": 1654
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2020 Presidential",
+            "subgroups": [
+              {
+                "key": "PRES20GJBI",
+                "name": "Democratic",
+                "sum": 2382204,
+                "min": 0,
+                "max": 5241
+              },
+              {
+                "key": "PRES20GDTR",
+                "name": "Republican",
+                "sum": 1167206,
+                "min": 0,
+                "max": 1991
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2020 US Senate",
+            "subgroups": [
+              {
+                "key": "SEN20GEMAR",
+                "name": "Democratic",
+                "sum": 2357811,
+                "min": 0,
+                "max": 5132
+              },
+              {
+                "key": "SEN20GKOCO",
+                "name": "Republican",
+                "sum": 1177759,
+                "min": 0,
+                "max": 2034
               }
             ]
           },
@@ -2306,8 +2566,14 @@
           "key": "GEOID20"
         },
         "bounds": [
-          [-73.5082, 41.1871],
-          [-69.8589, 42.8868]
+          [
+            -73.5082,
+            41.1871
+          ],
+          [
+            -69.8589,
+            42.8868
+          ]
         ],
         "tilesets": [
           {

--- a/assets/data/modules/Minnesota.json
+++ b/assets/data/modules/Minnesota.json
@@ -28,221 +28,101 @@
         "columnSets": [
           {
             "type": "election",
-            "name": "2012 Senate",
+            "name": "2018 US Senate",
             "subgroups": [
               {
-                "key": "SEN12D",
+                "key": "SEN18D",
                 "name": "Democratic",
-                "sum": 1854585,
+                "sum": 1566174,
                 "min": 0,
-                "max": 3384
+                "max": 2840
               },
               {
-                "key": "SEN12R",
+                "key": "SEN18R",
                 "name": "Republican",
-                "sum": 867968,
+                "sum": 940442,
                 "min": 0,
-                "max": 2293
+                "max": 2433
               }
             ]
           },
           {
             "type": "election",
-            "name": "2012 President",
+            "name": "2018 US Senate Special",
             "subgroups": [
               {
-                "key": "PRES12D",
+                "key": "SP_SEN18D",
                 "name": "Democratic",
-                "sum": 1546159,
+                "sum": 1370543,
                 "min": 0,
-                "max": 2682
+                "max": 2748
               },
               {
-                "key": "PRES12R",
+                "key": "SP_SEN18R",
                 "name": "Republican",
-                "sum": 1320220,
+                "sum": 1095775,
                 "min": 0,
-                "max": 3343
+                "max": 2796
               }
             ]
           },
           {
             "type": "election",
-            "name": "2014 Attorney General",
+            "name": "2018 US House",
             "subgroups": [
               {
-                "key": "AG14D",
+                "key": "USH18D",
                 "name": "Democratic",
-                "sum": 1014718,
+                "sum": 1420764,
                 "min": 0,
-                "max": 1649
+                "max": 2729
               },
               {
-                "key": "AG14R",
+                "key": "USH18R",
                 "name": "Republican",
-                "sum": 752542,
+                "sum": 1125536,
                 "min": 0,
-                "max": 1871
+                "max": 3058
               }
             ]
           },
           {
             "type": "election",
-            "name": "2014 Auditor",
+            "name": "2018 State Senate",
             "subgroups": [
               {
-                "key": "AUD14D",
+                "key": "SSEN18D",
                 "name": "Democratic",
-                "sum": 988099,
+                "sum": 16108,
                 "min": 0,
-                "max": 1654
+                "max": 974
               },
               {
-                "key": "AUD14R",
+                "key": "SSEN18R",
                 "name": "Republican",
-                "sum": 766813,
+                "sum": 21714,
                 "min": 0,
-                "max": 1891
+                "max": 1107
               }
             ]
           },
           {
             "type": "election",
-            "name": "2014 Secretary of State",
+            "name": "2018 State House",
             "subgroups": [
               {
-                "key": "SOS14D",
+                "key": "SH18D",
                 "name": "Democratic",
-                "sum": 901453,
+                "sum": 1388935,
                 "min": 0,
-                "max": 1647
+                "max": 2769
               },
               {
-                "key": "SOS14R",
+                "key": "SH18R",
                 "name": "Republican",
-                "sum": 879018,
+                "sum": 1151129,
                 "min": 0,
-                "max": 2135
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2014 Governor",
-            "subgroups": [
-              {
-                "key": "GOV14D",
-                "name": "Democratic",
-                "sum": 989107,
-                "min": 0,
-                "max": 1699
-              },
-              {
-                "key": "GOV14R",
-                "name": "Republican",
-                "sum": 879256,
-                "min": 0,
-                "max": 2190
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2014 Senate",
-            "subgroups": [
-              {
-                "key": "SEN14D",
-                "name": "Democratic",
-                "sum": 1053205,
-                "min": 0,
-                "max": 1756
-              },
-              {
-                "key": "SEN14R",
-                "name": "Republican",
-                "sum": 850224,
-                "min": 0,
-                "max": 2147
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2016 President",
-            "subgroups": [
-              {
-                "key": "PRES16D",
-                "name": "Democratic",
-                "sum": 1367701,
-                "min": 0,
-                "max": 2552
-              },
-              {
-                "key": "PRES16R",
-                "name": "Republican",
-                "sum": 1322937,
-                "min": 0,
-                "max": 3534
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2018 Attorney General",
-            "subgroups": [
-              {
-                "key": "AG18D",
-                "name": "Democratic",
-                "sum": 1249407,
-                "min": 0,
-                "max": 2460
-              },
-              {
-                "key": "AG18R",
-                "name": "Republican",
-                "sum": 1150460,
-                "min": 0,
-                "max": 2812
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2018 Auditor",
-            "subgroups": [
-              {
-                "key": "AUD18D",
-                "name": "Democratic",
-                "sum": 1250522,
-                "min": 0,
-                "max": 2390
-              },
-              {
-                "key": "AUD18R",
-                "name": "Republican",
-                "sum": 1095308,
-                "min": 0,
-                "max": 2655
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2018 Secretary of State",
-            "subgroups": [
-              {
-                "key": "SOS18D",
-                "name": "Democratic",
-                "sum": 1328502,
-                "min": 0,
-                "max": 2534
-              },
-              {
-                "key": "SOS18R",
-                "name": "Republican",
-                "sum": 1109095,
-                "min": 0,
-                "max": 2693
+                "max": 2917
               }
             ]
           },
@@ -255,34 +135,394 @@
                 "name": "Democratic",
                 "sum": 1393098,
                 "min": 0,
-                "max": 2593
+                "max": 2759
               },
               {
                 "key": "GOV18R",
                 "name": "Republican",
-                "sum": 1097704,
+                "sum": 1097705,
                 "min": 0,
-                "max": 2682
+                "max": 2766
               }
             ]
           },
           {
             "type": "election",
-            "name": "2018 Senate",
+            "name": "2018 Secretary of State",
             "subgroups": [
               {
-                "key": "SEN18D",
+                "key": "SOS18D",
                 "name": "Democratic",
-                "sum": 1566175,
+                "sum": 1328505,
                 "min": 0,
-                "max": 2671
+                "max": 2697
               },
               {
-                "key": "SEN18R",
+                "key": "SOS18R",
                 "name": "Republican",
-                "sum": 940436,
+                "sum": 1109094,
                 "min": 0,
-                "max": 2360
+                "max": 2776
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 State Auditor",
+            "subgroups": [
+              {
+                "key": "AUD18D",
+                "name": "Democratic",
+                "sum": 1250528,
+                "min": 0,
+                "max": 2542
+              },
+              {
+                "key": "AUD18R",
+                "name": "Republican",
+                "sum": 1095312,
+                "min": 0,
+                "max": 2736
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Attorney General",
+            "subgroups": [
+              {
+                "key": "AG18D",
+                "name": "Democratic",
+                "sum": 1249412,
+                "min": 0,
+                "max": 2617
+              },
+              {
+                "key": "AG18R",
+                "name": "Republican",
+                "sum": 1150457,
+                "min": 0,
+                "max": 2899
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 Presidential",
+            "subgroups": [
+              {
+                "key": "PRES16D",
+                "name": "Democratic",
+                "sum": 1367700,
+                "min": 0,
+                "max": 2721
+              },
+              {
+                "key": "PRES16R",
+                "name": "Republican",
+                "sum": 1322941,
+                "min": 0,
+                "max": 3331
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 US House",
+            "subgroups": [
+              {
+                "key": "USH16D",
+                "name": "Democratic",
+                "sum": 1434570,
+                "min": 0,
+                "max": 2417
+              },
+              {
+                "key": "USH16R",
+                "name": "Republican",
+                "sum": 1334673,
+                "min": 0,
+                "max": 3811
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 State Senate",
+            "subgroups": [
+              {
+                "key": "SSEN16D",
+                "name": "Democratic",
+                "sum": 1409768,
+                "min": 0,
+                "max": 2585
+              },
+              {
+                "key": "SSEN16R",
+                "name": "Republican",
+                "sum": 1377117,
+                "min": 0,
+                "max": 3794
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 State House",
+            "subgroups": [
+              {
+                "key": "SH16D",
+                "name": "Democratic",
+                "sum": 1366364,
+                "min": 0,
+                "max": 2465
+              },
+              {
+                "key": "SH16R",
+                "name": "Republican",
+                "sum": 1400574,
+                "min": 0,
+                "max": 3658
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 US Senate",
+            "subgroups": [
+              {
+                "key": "SEN14D",
+                "name": "Democratic",
+                "sum": 1053199,
+                "min": 0,
+                "max": 1756
+              },
+              {
+                "key": "SEN14R",
+                "name": "Republican",
+                "sum": 850228,
+                "min": 0,
+                "max": 2208
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 US House",
+            "subgroups": [
+              {
+                "key": "USH14D",
+                "name": "Democratic",
+                "sum": 985750,
+                "min": 0,
+                "max": 1758
+              },
+              {
+                "key": "USH14R",
+                "name": "Republican",
+                "sum": 913529,
+                "min": 0,
+                "max": 2335
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 State House",
+            "subgroups": [
+              {
+                "key": "SH14D",
+                "name": "Democratic",
+                "sum": 944959,
+                "min": 0,
+                "max": 1729
+              },
+              {
+                "key": "SH14R",
+                "name": "Republican",
+                "sum": 958664,
+                "min": 0,
+                "max": 2376
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 Governor",
+            "subgroups": [
+              {
+                "key": "GOV14D",
+                "name": "Democratic",
+                "sum": 989110,
+                "min": 0,
+                "max": 1699
+              },
+              {
+                "key": "GOV14R",
+                "name": "Republican",
+                "sum": 879252,
+                "min": 0,
+                "max": 2252
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 Secretary of State",
+            "subgroups": [
+              {
+                "key": "SOS14D",
+                "name": "Democratic",
+                "sum": 901455,
+                "min": 0,
+                "max": 1647
+              },
+              {
+                "key": "SOS14R",
+                "name": "Republican",
+                "sum": 879024,
+                "min": 0,
+                "max": 2196
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 State Auditor",
+            "subgroups": [
+              {
+                "key": "AUD14D",
+                "name": "Democratic",
+                "sum": 988093,
+                "min": 0,
+                "max": 1654
+              },
+              {
+                "key": "AUD14R",
+                "name": "Republican",
+                "sum": 766811,
+                "min": 0,
+                "max": 1944
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 Attorney General",
+            "subgroups": [
+              {
+                "key": "AG14D",
+                "name": "Democratic",
+                "sum": 1014723,
+                "min": 0,
+                "max": 1591
+              },
+              {
+                "key": "AG14R",
+                "name": "Republican",
+                "sum": 752543,
+                "min": 0,
+                "max": 1924
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 Presidential",
+            "subgroups": [
+              {
+                "key": "PRES12D",
+                "name": "Democratic",
+                "sum": 1546159,
+                "min": 0,
+                "max": 2467
+              },
+              {
+                "key": "PRES12R",
+                "name": "Republican",
+                "sum": 1320217,
+                "min": 0,
+                "max": 3453
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 US Senate",
+            "subgroups": [
+              {
+                "key": "SEN12D",
+                "name": "Democratic",
+                "sum": 1854587,
+                "min": 0,
+                "max": 2725
+              },
+              {
+                "key": "SEN12R",
+                "name": "Republican",
+                "sum": 867981,
+                "min": 0,
+                "max": 2368
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 US House",
+            "subgroups": [
+              {
+                "key": "USH12D",
+                "name": "Democratic",
+                "sum": 1560966,
+                "min": 0,
+                "max": 2318
+              },
+              {
+                "key": "USH12R",
+                "name": "Republican",
+                "sum": 1210390,
+                "min": 0,
+                "max": 2944
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 State Senate",
+            "subgroups": [
+              {
+                "key": "SSEN12D",
+                "name": "Democratic",
+                "sum": 1532044,
+                "min": 0,
+                "max": 2437
+              },
+              {
+                "key": "SSEN12R",
+                "name": "Republican",
+                "sum": 1193349,
+                "min": 0,
+                "max": 3300
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 State House",
+            "subgroups": [
+              {
+                "key": "SH12D",
+                "name": "Democratic",
+                "sum": 1468355,
+                "min": 0,
+                "max": 2267
+              },
+              {
+                "key": "SH12R",
+                "name": "Republican",
+                "sum": 1233207,
+                "min": 0,
+                "max": 3116
               }
             ]
           },
@@ -290,7 +530,7 @@
             "type": "population",
             "name": "Population",
             "total": {
-              "key": "TOTPOP",
+              "key": "TOTPOP20",
               "name": "Total population",
               "sum": 5706494,
               "min": 0,
@@ -298,56 +538,56 @@
             },
             "subgroups": [
               {
-                "key": "WHITE",
+                "key": "WPOP20",
                 "name": "White population",
                 "sum": 4353880,
                 "min": 0,
                 "max": 9570
               },
               {
-                "key": "BLACK",
+                "key": "BPOP20",
                 "name": "Black population",
                 "sum": 392850,
                 "min": 0,
                 "max": 4357
               },
               {
-                "key": "HISP",
+                "key": "HISP20",
                 "name": "Hispanic population",
                 "sum": 345640,
                 "min": 0,
                 "max": 2095
               },
               {
-                "key": "ASIAN",
+                "key": "ASIANPOP20",
                 "name": "Asian population",
                 "sum": 297460,
                 "min": 0,
                 "max": 3113
               },
               {
-                "key": "AMIN",
+                "key": "AMINPOP20",
                 "name": "American Indian population",
                 "sum": 57046,
                 "min": 0,
                 "max": 2303
               },
               {
-                "key": "NHPI",
+                "key": "NHPIPOP20",
                 "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 2621,
                 "min": 0,
                 "max": 200
               },
               {
-                "key": "2MORE",
+                "key": "2MOREPOP20",
                 "name": "Two or more races",
                 "sum": 236034,
                 "min": 0,
                 "max": 533
               },
               {
-                "key": "OTHER",
+                "key": "OTHERPOP20",
                 "name": "Other races",
                 "sum": 20963,
                 "min": 0,
@@ -359,7 +599,7 @@
             "type": "population",
             "name": "Voting Age Population",
             "total": {
-              "key": "VAP",
+              "key": "VAP20",
               "name": "Voting age population",
               "sum": 4389033,
               "min": 0,
@@ -367,56 +607,56 @@
             },
             "subgroups": [
               {
-                "key": "WVAP",
+                "key": "WVAP20",
                 "name": "White voting age population",
                 "sum": 3509053,
                 "min": 0,
                 "max": 6460
               },
               {
-                "key": "BVAP",
+                "key": "BVAP20",
                 "name": "Black voting age population",
                 "sum": 257353,
                 "min": 0,
                 "max": 2888
               },
               {
-                "key": "HVAP",
+                "key": "HVAP20",
                 "name": "Hispanic voting age population",
                 "sum": 218767,
                 "min": 0,
                 "max": 1298
               },
               {
-                "key": "AMINVAP",
+                "key": "AMINVAP20",
                 "name": "Native American voting age population",
                 "sum": 39560,
                 "min": 0,
                 "max": 1453
               },
               {
-                "key": "NHPIVAP",
+                "key": "NHPIVAP20",
                 "name": "Native Hawaiian and Pacific Islander voting age population",
                 "sum": 1861,
                 "min": 0,
                 "max": 123
               },
               {
-                "key": "ASIANVAP",
+                "key": "ASIANVAP20",
                 "name": "Asian voting age population",
                 "sum": 214681,
                 "min": 0,
                 "max": 2297
               },
               {
-                "key": "OTHERVAP",
+                "key": "OTHERVAP20",
                 "name": "Other races voting age population",
                 "sum": 14680,
                 "min": 0,
                 "max": 122
               },
               {
-                "key": "2MOREVAP",
+                "key": "2MOREVAP20",
                 "name": "Two or more races voting age population",
                 "sum": 133078,
                 "min": 0,
@@ -430,8 +670,14 @@
           "key": "GEOID20"
         },
         "bounds": [
-          [-97.2391, 43.4994],
-          [-89.4834, 49.3845]
+          [
+            -97.2391,
+            43.4994
+          ],
+          [
+            -89.4834,
+            49.3845
+          ]
         ],
         "tilesets": [
           {
@@ -441,14 +687,6 @@
               "url": "mapbox://districtr.mn_vtds20"
             },
             "sourceLayer": "mn_vtds20"
-          },
-          {
-            "type": "circle",
-            "source": {
-              "type": "vector",
-              "url": "mapbox://districtr.mn_vtds20_points"
-            },
-            "sourceLayer": "mn_vtds20_points"
           }
         ]
       },

--- a/assets/data/modules/Nebraska.json
+++ b/assets/data/modules/Nebraska.json
@@ -12,14 +12,14 @@
             "name": "2018 Governor",
             "subgroups": [
               {
-                "key": "GOV18D",
+                "key": "GOV18D+",
                 "name": "Democratic",
                 "sum": 286270,
                 "min": 0,
                 "max": 1038
               },
               {
-                "key": "GOV18R",
+                "key": "GOV18R+",
                 "name": "Republican",
                 "sum": 412429,
                 "min": 0,
@@ -29,17 +29,37 @@
           },
           {
             "type": "election",
+            "name": "2018 US House",
+            "subgroups": [
+              {
+                "key": "USH18D+",
+                "name": "Democratic",
+                "sum": 264582,
+                "min": 0,
+                "max": 1036
+              },
+              {
+                "key": "USH18R+",
+                "name": "Republican",
+                "sum": 432733,
+                "min": 0,
+                "max": 1842
+              }
+            ]
+          },
+          {
+            "type": "election",
             "name": "2018 Secretary of State",
             "subgroups": [
               {
-                "key": "SOS18D",
+                "key": "SOS18D+",
                 "name": "Democratic",
                 "sum": 264045,
                 "min": 0,
                 "max": 1004
               },
               {
-                "key": "SOS18R",
+                "key": "SOS18R+",
                 "name": "Republican",
                 "sum": 407224,
                 "min": 0,
@@ -187,12 +207,18 @@
           }
         ],
         "idColumn": {
-          "name": "2020 Census GEOID",
+          "name": "VTD GEOID code",
           "key": "GEOID20"
         },
         "bounds": [
-          [-104.0535, 39.9999],
-          [-95.3083, 43.0017]
+          [
+            -104.0535,
+            39.9999
+          ],
+          [
+            -95.3083,
+            43.0017
+          ]
         ],
         "tilesets": [
           {

--- a/assets/data/modules/New Hampshire.json
+++ b/assets/data/modules/New Hampshire.json
@@ -9,7 +9,7 @@
         "columnSets": [
           {
             "type": "election",
-            "name": "2012 President",
+            "name": "2012 Presidential",
             "subgroups": [
               {
                 "key": "PRES12D",
@@ -49,6 +49,26 @@
           },
           {
             "type": "election",
+            "name": "2012 US House",
+            "subgroups": [
+              {
+                "key": "USH12D",
+                "name": "Democratic",
+                "sum": 340925,
+                "min": 0,
+                "max": 7316
+              },
+              {
+                "key": "USH12R",
+                "name": "Republican",
+                "sum": 311636,
+                "min": 0,
+                "max": 7558
+              }
+            ]
+          },
+          {
+            "type": "election",
             "name": "2014 Governor",
             "subgroups": [
               {
@@ -69,7 +89,7 @@
           },
           {
             "type": "election",
-            "name": "2016 President",
+            "name": "2016 Presidential",
             "subgroups": [
               {
                 "key": "PRES16D",
@@ -109,7 +129,7 @@
           },
           {
             "type": "election",
-            "name": "2016 Senate",
+            "name": "2016 US Senate",
             "subgroups": [
               {
                 "key": "SEN16D",
@@ -129,7 +149,27 @@
           },
           {
             "type": "election",
-            "name": "2016 Governor",
+            "name": "2016 US House",
+            "subgroups": [
+              {
+                "key": "USH16D",
+                "name": "Democratic",
+                "sum": 336575,
+                "min": 0,
+                "max": 6359
+              },
+              {
+                "key": "USH16R",
+                "name": "Republican",
+                "sum": 316367,
+                "min": 0,
+                "max": 8084
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Governor",
             "subgroups": [
               {
                 "key": "GOV18D",
@@ -144,46 +184,6 @@
                 "sum": 302764,
                 "min": 0,
                 "max": 7293
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2020 President",
-            "subgroups": [
-              {
-                "key": "PRES20D",
-                "name": "Democratic",
-                "sum": 424937,
-                "min": 0,
-                "max": 8725
-              },
-              {
-                "key": "PRES20R",
-                "name": "Republican",
-                "sum": 365660,
-                "min": 0,
-                "max": 9969
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2020 Senate",
-            "subgroups": [
-              {
-                "key": "SEN20D",
-                "name": "Democratic",
-                "sum": 450778,
-                "min": 0,
-                "max": 9229
-              },
-              {
-                "key": "SEN20R",
-                "name": "Republican",
-                "sum": 326229,
-                "min": 0,
-                "max": 8716
               }
             ]
           },
@@ -204,6 +204,66 @@
                 "sum": 516609,
                 "min": 0,
                 "max": 13202
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Presidential",
+            "subgroups": [
+              {
+                "key": "PRES20D",
+                "name": "Democratic",
+                "sum": 424937,
+                "min": 0,
+                "max": 8725
+              },
+              {
+                "key": "PRES20R",
+                "name": "Republican",
+                "sum": 365660,
+                "min": 0,
+                "max": 9969
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2020 US House",
+            "subgroups": [
+              {
+                "key": "USH20D",
+                "name": "Democratic",
+                "sum": 413895,
+                "min": 0,
+                "max": 8245
+              },
+              {
+                "key": "USH20R",
+                "name": "Republican",
+                "sum": 354045,
+                "min": 0,
+                "max": 9292
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2020 US Senate",
+            "subgroups": [
+              {
+                "key": "SEN20D",
+                "name": "Democratic",
+                "sum": 450778,
+                "min": 0,
+                "max": 9229
+              },
+              {
+                "key": "SEN20R",
+                "name": "Republican",
+                "sum": 326229,
+                "min": 0,
+                "max": 8716
               }
             ]
           },
@@ -347,12 +407,18 @@
           }
         ],
         "idColumn": {
-          "name": "2020 Census GEOID",
+          "name": "VTD GEOID code",
           "key": "GEOID20"
         },
         "bounds": [
-          [-72.5571, 42.697],
-          [-70.5751, 45.3058]
+          [
+            -72.5571,
+            42.697
+          ],
+          [
+            -70.5751,
+            45.3058
+          ]
         ],
         "tilesets": [
           {

--- a/assets/data/modules/North Carolina.json
+++ b/assets/data/modules/North Carolina.json
@@ -1799,56 +1799,56 @@
               {
                 "key": "EL08G_GV_D",
                 "name": "Democratic",
-                "sum": 2138046,
+                "sum": 2138043,
                 "min": 0,
-                "max": 9439
+                "max": 4059
               },
               {
                 "key": "EL08G_GV_R",
                 "name": "Republican",
-                "sum": 1997134,
+                "sum": 1997148,
                 "min": 0,
-                "max": 6430
+                "max": 4382
               }
             ]
           },
           {
             "type": "election",
-            "name": "2008 Senate",
+            "name": "2008 US Senate",
             "subgroups": [
               {
                 "key": "EL08G_USS_",
                 "name": "Democratic",
-                "sum": 2240835,
+                "sum": 2240838,
                 "min": 0,
-                "max": 9332
+                "max": 4471
               },
               {
                 "key": "EL08G_US_1",
                 "name": "Republican",
-                "sum": 1883929,
+                "sum": 1883930,
                 "min": 0,
-                "max": 5236
+                "max": 3470
               }
             ]
           },
           {
             "type": "election",
-            "name": "2010 Senate",
+            "name": "2010 US Senate",
             "subgroups": [
               {
                 "key": "EL10G_USS_",
                 "name": "Democratic",
-                "sum": 1141697,
+                "sum": 1141690,
                 "min": 0,
-                "max": 4882
+                "max": 2733
               },
               {
                 "key": "EL10G_US_1",
                 "name": "Republican",
-                "sum": 1454082,
+                "sum": 1454083,
                 "min": 0,
-                "max": 3848
+                "max": 2694
               }
             ]
           },
@@ -1859,36 +1859,16 @@
               {
                 "key": "EL12G_GV_D",
                 "name": "Democratic",
-                "sum": 1925267,
+                "sum": 1925272,
                 "min": 0,
-                "max": 9068
+                "max": 4277
               },
               {
                 "key": "EL12G_GV_R",
                 "name": "Republican",
-                "sum": 2437225,
+                "sum": 2437221,
                 "min": 0,
-                "max": 8101
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2012 President",
-            "subgroups": [
-              {
-                "key": "EL12G_PR_D",
-                "name": "Democratic",
-                "sum": 2171289,
-                "min": 0,
-                "max": 9734
-              },
-              {
-                "key": "EL12G_PR_R",
-                "name": "Republican",
-                "sum": 2267351,
-                "min": 0,
-                "max": 7192
+                "max": 4978
               }
             ]
           },
@@ -1899,36 +1879,76 @@
               {
                 "key": "EL14G_USS_",
                 "name": "Democratic",
-                "sum": 1416838,
+                "sum": 1416842,
                 "min": 0,
-                "max": 4539
+                "max": 3024
               },
               {
                 "key": "EL14G_US_1",
                 "name": "Republican",
-                "sum": 1370301,
+                "sum": 1370298,
                 "min": 0,
-                "max": 5821
+                "max": 3455
               }
             ]
           },
           {
             "type": "election",
-            "name": "2016 President",
+            "name": "2012 Presidential",
+            "subgroups": [
+              {
+                "key": "EL12G_PR_D",
+                "name": "Democratic",
+                "sum": 2171298,
+                "min": 0,
+                "max": 4879
+              },
+              {
+                "key": "EL12G_PR_R",
+                "name": "Republican",
+                "sum": 2267344,
+                "min": 0,
+                "max": 4503
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 Presidential",
             "subgroups": [
               {
                 "key": "EL16G_PR_D",
                 "name": "Democratic",
-                "sum": 2180319,
+                "sum": 2180326,
                 "min": 0,
-                "max": 9556
+                "max": 5211
               },
               {
                 "key": "EL16G_PR_R",
                 "name": "Republican",
-                "sum": 2359753,
+                "sum": 2359750,
                 "min": 0,
-                "max": 7202
+                "max": 4808
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 US Senate",
+            "subgroups": [
+              {
+                "key": "EL16G_US_1",
+                "name": "Democratic",
+                "sum": 2119699,
+                "min": 0,
+                "max": 5059
+              },
+              {
+                "key": "EL16G_USS_",
+                "name": "Republican",
+                "sum": 2392433,
+                "min": 0,
+                "max": 4819
               }
             ]
           },
@@ -1939,16 +1959,16 @@
               {
                 "key": "EL16G_GV_D",
                 "name": "Democratic",
-                "sum": 2300380,
+                "sum": 2300389,
                 "min": 0,
-                "max": 9363
+                "max": 5289
               },
               {
                 "key": "EL16G_GV_R",
                 "name": "Republican",
-                "sum": 2296036,
+                "sum": 2296035,
                 "min": 0,
-                "max": 7376
+                "max": 4381
               }
             ]
           },
@@ -2092,12 +2112,18 @@
           }
         ],
         "idColumn": {
-          "name": "2020 Census GEOID",
+          "name": "VTD GEOID code",
           "key": "GEOID20"
         },
         "bounds": [
-          [-84.3218, 33.7529],
-          [-75.4001, 36.5881]
+          [
+            -84.3218,
+            33.7529
+          ],
+          [
+            -75.4001,
+            36.5881
+          ]
         ],
         "tilesets": [
           {

--- a/assets/data/modules/Ohio.json
+++ b/assets/data/modules/Ohio.json
@@ -536,11 +536,251 @@
         "unitType": "VTDs",
         "columnSets": [
           {
+            "type": "election",
+            "name": "2016 Presidential",
+            "subgroups": [
+              {
+                "key": "PRES16D",
+                "name": "Democratic",
+                "sum": 2393913,
+                "min": 0,
+                "max": 1692
+              },
+              {
+                "key": "PRES16R",
+                "name": "Republican",
+                "sum": 2840372,
+                "min": 0,
+                "max": 1044
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 US Senate",
+            "subgroups": [
+              {
+                "key": "SEN16D",
+                "name": "Democratic",
+                "sum": 1996910,
+                "min": 0,
+                "max": 1331
+              },
+              {
+                "key": "SEN16R",
+                "name": "Republican",
+                "sum": 3118570,
+                "min": 0,
+                "max": 1060
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 US House",
+            "subgroups": [
+              {
+                "key": "USH16D",
+                "name": "Democratic",
+                "sum": 2154523,
+                "min": 0,
+                "max": 1390
+              },
+              {
+                "key": "USH16R",
+                "name": "Republican",
+                "sum": 2996016,
+                "min": 0,
+                "max": 1100
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 State Senate",
+            "subgroups": [
+              {
+                "key": "SSEN16D",
+                "name": "Democratic",
+                "sum": 821821,
+                "min": 0,
+                "max": 732
+              },
+              {
+                "key": "SSEN16R",
+                "name": "Republican",
+                "sum": 1640505,
+                "min": 0,
+                "max": 996
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 State House",
+            "subgroups": [
+              {
+                "key": "STH16D",
+                "name": "Democratic",
+                "sum": 1961345,
+                "min": 0,
+                "max": 1236
+              },
+              {
+                "key": "STH16R",
+                "name": "Republican",
+                "sum": 2836621,
+                "min": 0,
+                "max": 1025
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Governor",
+            "subgroups": [
+              {
+                "key": "GOV18D",
+                "name": "Democratic",
+                "sum": 2070048,
+                "min": 0,
+                "max": 935
+              },
+              {
+                "key": "GOV18R",
+                "name": "Republican",
+                "sum": 2235830,
+                "min": 0,
+                "max": 909
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Attorney General",
+            "subgroups": [
+              {
+                "key": "AG18D",
+                "name": "Democratic",
+                "sum": 2086708,
+                "min": 0,
+                "max": 892
+              },
+              {
+                "key": "AG18R",
+                "name": "Republican",
+                "sum": 2276421,
+                "min": 0,
+                "max": 891
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 State Auditor",
+            "subgroups": [
+              {
+                "key": "AUD18D",
+                "name": "Democratic",
+                "sum": 2008295,
+                "min": 0,
+                "max": 914
+              },
+              {
+                "key": "AUD18R",
+                "name": "Republican",
+                "sum": 2156660,
+                "min": 0,
+                "max": 886
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Secretary of State",
+            "subgroups": [
+              {
+                "key": "SOS18D",
+                "name": "Democratic",
+                "sum": 2052107,
+                "min": 0,
+                "max": 911
+              },
+              {
+                "key": "SOS18R",
+                "name": "Republican",
+                "sum": 2214279,
+                "min": 0,
+                "max": 880
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Treasurer",
+            "subgroups": [
+              {
+                "key": "TRE18D",
+                "name": "Democratic",
+                "sum": 2024198,
+                "min": 0,
+                "max": 901
+              },
+              {
+                "key": "TRE18R",
+                "name": "Republican",
+                "sum": 2308427,
+                "min": 0,
+                "max": 912
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 US Senate",
+            "subgroups": [
+              {
+                "key": "SEN18D",
+                "name": "Democratic",
+                "sum": 2358511,
+                "min": 0,
+                "max": 969
+              },
+              {
+                "key": "SEN18R",
+                "name": "Republican",
+                "sum": 2057553,
+                "min": 0,
+                "max": 860
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2020 Presidential",
+            "subgroups": [
+              {
+                "key": "PRES20D_Bi",
+                "name": "Democratic",
+                "sum": 2679165,
+                "min": 0,
+                "max": 1120
+              },
+              {
+                "key": "PRES20R_Tr",
+                "name": "Republican",
+                "sum": 3154834,
+                "min": 0,
+                "max": 1293
+              }
+            ]
+          },
+          {
             "type": "population",
             "name": "Population",
             "total": {
               "key": "TOTPOP",
-              "name": "Total Population",
+              "name": "Total population",
               "sum": 11799448,
               "min": 0,
               "max": 6495
@@ -561,11 +801,11 @@
                 "max": 2804
               },
               {
-                "key": "AMIN",
-                "name": "American Indian population",
-                "sum": 18949,
+                "key": "HISP",
+                "name": "Hispanic population",
+                "sum": 521308,
                 "min": 0,
-                "max": 33
+                "max": 1415
               },
               {
                 "key": "ASIAN",
@@ -575,18 +815,18 @@
                 "max": 1198
               },
               {
+                "key": "AMIN",
+                "name": "American Indian population",
+                "sum": 18949,
+                "min": 0,
+                "max": 33
+              },
+              {
                 "key": "NHPI",
-                "name": "Native Hawaiian and Pacific Islanders population",
+                "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 4493,
                 "min": 0,
                 "max": 161
-              },
-              {
-                "key": "OTHER",
-                "name": "Other races",
-                "sum": 45217,
-                "min": 0,
-                "max": 154
               },
               {
                 "key": "2MORE",
@@ -596,11 +836,11 @@
                 "max": 272
               },
               {
-                "key": "HISP",
-                "name": "Hispanic population",
-                "sum": 521308,
+                "key": "OTHER",
+                "name": "Other races",
+                "sum": 45217,
                 "min": 0,
-                "max": 1415
+                "max": 154
               }
             ]
           },
@@ -630,11 +870,25 @@
                 "max": 2770
               },
               {
+                "key": "HVAP",
+                "name": "Hispanic voting age population",
+                "sum": 336028,
+                "min": 0,
+                "max": 881
+              },
+              {
                 "key": "AMINVAP",
-                "name": "American Indian voting age population",
+                "name": "Native American voting age population",
                 "sum": 15496,
                 "min": 0,
                 "max": 29
+              },
+              {
+                "key": "NHPIVAP",
+                "name": "Native Hawaiian and Pacific Islander voting age population",
+                "sum": 3233,
+                "min": 0,
+                "max": 92
               },
               {
                 "key": "ASIANVAP",
@@ -642,13 +896,6 @@
                 "sum": 228920,
                 "min": 0,
                 "max": 1043
-              },
-              {
-                "key": "NHPIVAP",
-                "name": "Native Hawaiian and Pacific Islanders voting age population",
-                "sum": 3233,
-                "min": 0,
-                "max": 92
               },
               {
                 "key": "OTHERVAP",
@@ -663,24 +910,23 @@
                 "sum": 302248,
                 "min": 0,
                 "max": 185
-              },
-              {
-                "key": "HVAP",
-                "name": "Hispanic voting age population",
-                "sum": 336028,
-                "min": 0,
-                "max": 881
               }
             ]
           }
         ],
         "idColumn": {
-          "name": "2020 Census GEOID",
+          "name": "VTD GEOID code",
           "key": "GEOID20"
         },
         "bounds": [
-          [-84.8203, 38.4034],
-          [-80.5187, 42.3271]
+          [
+            -84.8203,
+            38.4034
+          ],
+          [
+            -80.5187,
+            42.3271
+          ]
         ],
         "tilesets": [
           {

--- a/assets/data/modules/Oklahoma.json
+++ b/assets/data/modules/Oklahoma.json
@@ -8,6 +8,66 @@
         "columnSets": [
           {
             "type": "election",
+            "name": "2018 Governor",
+            "subgroups": [
+              {
+                "key": "GOV18D",
+                "name": "Democratic",
+                "sum": 500976,
+                "min": 0,
+                "max": 1403
+              },
+              {
+                "key": "GOV18R",
+                "name": "Republican",
+                "sum": 644577,
+                "min": 0,
+                "max": 1852
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Lt. Governor",
+            "subgroups": [
+              {
+                "key": "LG18D",
+                "name": "Democratic",
+                "sum": 406796,
+                "min": 0,
+                "max": 1170
+              },
+              {
+                "key": "LG18R",
+                "name": "Republican",
+                "sum": 729222,
+                "min": 0,
+                "max": 2167
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 US House",
+            "subgroups": [
+              {
+                "key": "USH18D",
+                "name": "Democratic",
+                "sum": 428459,
+                "min": 0,
+                "max": 1194
+              },
+              {
+                "key": "USH18R",
+                "name": "Republican",
+                "sum": 730540,
+                "min": 0,
+                "max": 2249
+              }
+            ]
+          },
+          {
+            "type": "election",
             "name": "2018 Attorney General",
             "subgroups": [
               {
@@ -20,7 +80,7 @@
               {
                 "key": "AG18R",
                 "name": "Republican",
-                "sum": 750772,
+                "sum": 750775,
                 "min": 0,
                 "max": 2265
               }
@@ -28,21 +88,41 @@
           },
           {
             "type": "election",
-            "name": "2018 Governor",
+            "name": "2018 State Auditor",
             "subgroups": [
               {
-                "key": "GOV18D",
-                "name": "Democratic",
-                "sum": 500975,
+                "key": "AUD18L",
+                "name": "Libertarian",
+                "sum": 270311,
                 "min": 0,
-                "max": 1403
+                "max": 750
               },
               {
-                "key": "GOV18R",
+                "key": "AUD18R",
                 "name": "Republican",
-                "sum": 644579,
+                "sum": 818855,
                 "min": 0,
-                "max": 1852
+                "max": 2434
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 Treasurer",
+            "subgroups": [
+              {
+                "key": "TRE18I",
+                "name": "Independent",
+                "sum": 309530,
+                "min": 0,
+                "max": 851
+              },
+              {
+                "key": "TRE18R",
+                "name": "Republican",
+                "sum": 779658,
+                "min": 0,
+                "max": 2290
               }
             ]
           },
@@ -186,12 +266,18 @@
           }
         ],
         "idColumn": {
-          "name": "2020 Census GEOID",
+          "name": "VTD GEOID code",
           "key": "GEOID20"
         },
         "bounds": [
-          [-103.0024, 33.6158],
-          [-94.431, 37.0023]
+          [
+            -103.0024,
+            33.6158
+          ],
+          [
+            -94.431,
+            37.0023
+          ]
         ],
         "tilesets": [
           {

--- a/assets/data/modules/Pennsylvania.json
+++ b/assets/data/modules/Pennsylvania.json
@@ -33,17 +33,17 @@
         "columnSets": [
           {
             "type": "election",
-            "name": "2016 President",
+            "name": "2016 Presidential",
             "subgroups": [
               {
-                "key": "PRES16D",
+                "key": "G16PREDCLI",
                 "name": "Democratic",
                 "sum": 2926393,
                 "min": 0,
                 "max": 3896
               },
               {
-                "key": "PRES16R",
+                "key": "G16PRERTRU",
                 "name": "Republican",
                 "sum": 2971090,
                 "min": 0,
@@ -53,17 +53,17 @@
           },
           {
             "type": "election",
-            "name": "2016 Senate",
+            "name": "2016 US Senate",
             "subgroups": [
               {
-                "key": "SEN16D",
+                "key": "G16USSDMCG",
                 "name": "Democratic",
                 "sum": 2864967,
                 "min": 0,
                 "max": 3444
               },
               {
-                "key": "SEN16R",
+                "key": "G16USSRTOO",
                 "name": "Republican",
                 "sum": 2951591,
                 "min": 0,
@@ -73,37 +73,17 @@
           },
           {
             "type": "election",
-            "name": "2016 Auditor",
-            "subgroups": [
-              {
-                "key": "AUD16D",
-                "name": "Democratic",
-                "sum": 2958764,
-                "min": 0,
-                "max": 3153
-              },
-              {
-                "key": "AUD16R",
-                "name": "Republican",
-                "sum": 2667219,
-                "min": 0,
-                "max": 2254
-              }
-            ]
-          },
-          {
-            "type": "election",
             "name": "2016 Attorney General",
             "subgroups": [
               {
-                "key": "AG16D",
+                "key": "G16ATGDSHA",
                 "name": "Democratic",
                 "sum": 3056953,
                 "min": 0,
                 "max": 3698
               },
               {
-                "key": "AG16R",
+                "key": "G16ATGRRAF",
                 "name": "Republican",
                 "sum": 2891216,
                 "min": 0,
@@ -113,17 +93,77 @@
           },
           {
             "type": "election",
+            "name": "2016 Treasurer",
+            "subgroups": [
+              {
+                "key": "G16TREDTOR",
+                "name": "Democratic",
+                "sum": 2991357,
+                "min": 0,
+                "max": 3152
+              },
+              {
+                "key": "G16TRERVOI",
+                "name": "Republican",
+                "sum": 2610706,
+                "min": 0,
+                "max": 2277
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 State Auditor",
+            "subgroups": [
+              {
+                "key": "G16AUDDDEP",
+                "name": "Democratic",
+                "sum": 2958764,
+                "min": 0,
+                "max": 3153
+              },
+              {
+                "key": "G16AUDRBRO",
+                "name": "Republican",
+                "sum": 2667219,
+                "min": 0,
+                "max": 2254
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 US Senate",
+            "subgroups": [
+              {
+                "key": "G18USSDCAS",
+                "name": "Democratic",
+                "sum": 2792687,
+                "min": 0,
+                "max": 2681
+              },
+              {
+                "key": "G18USSRBAR",
+                "name": "Republican",
+                "sum": 2135231,
+                "min": 0,
+                "max": 1858
+              }
+            ]
+          },
+          {
+            "type": "election",
             "name": "2018 Governor",
             "subgroups": [
               {
-                "key": "GOV18D",
+                "key": "G18GOVDWOL",
                 "name": "Democratic",
                 "sum": 2895937,
                 "min": 0,
                 "max": 2745
               },
               {
-                "key": "GOV18R",
+                "key": "G18GOVRWAG",
                 "name": "Republican",
                 "sum": 2040226,
                 "min": 0,
@@ -133,21 +173,141 @@
           },
           {
             "type": "election",
-            "name": "2018 Senate",
+            "name": "2014 Governor",
             "subgroups": [
               {
-                "key": "SEN18D",
+                "key": "GOV14D",
                 "name": "Democratic",
-                "sum": 2792687,
+                "sum": 1909492,
                 "min": 0,
-                "max": 2681
+                "max": 1149
               },
               {
-                "key": "SEN18R",
+                "key": "GOV14R",
                 "name": "Republican",
-                "sum": 2135231,
+                "sum": 1568804,
                 "min": 0,
-                "max": 1858
+                "max": 1504
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2014 State House",
+            "subgroups": [
+              {
+                "key": "STH14DEM",
+                "name": "Democratic",
+                "sum": 1214381,
+                "min": 0,
+                "max": 1283
+              },
+              {
+                "key": "STH14REP",
+                "name": "Republican",
+                "sum": 1378876,
+                "min": 0,
+                "max": 2111
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 US Senate",
+            "subgroups": [
+              {
+                "key": "USS12D",
+                "name": "Democratic",
+                "sum": 3013945,
+                "min": 0,
+                "max": 2987
+              },
+              {
+                "key": "USS12R",
+                "name": "Republican",
+                "sum": 2509690,
+                "min": 0,
+                "max": 2328
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2010 US Senate",
+            "subgroups": [
+              {
+                "key": "SEN10D",
+                "name": "Democratic",
+                "sum": 1944073,
+                "min": 0,
+                "max": 1225
+              },
+              {
+                "key": "SEN10R",
+                "name": "Republican",
+                "sum": 2027654,
+                "min": 0,
+                "max": 1788
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 Presidential",
+            "subgroups": [
+              {
+                "key": "PRES12D",
+                "name": "Democratic",
+                "sum": 2983858,
+                "min": 0,
+                "max": 3186
+              },
+              {
+                "key": "PRES12R",
+                "name": "Republican",
+                "sum": 2676864,
+                "min": 0,
+                "max": 2486
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2010 Governor",
+            "subgroups": [
+              {
+                "key": "GOV10D",
+                "name": "Democratic",
+                "sum": 1810600,
+                "min": 0,
+                "max": 1179
+              },
+              {
+                "key": "GOV10R",
+                "name": "Republican",
+                "sum": 2170485,
+                "min": 0,
+                "max": 1892
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2012 Attorney General",
+            "subgroups": [
+              {
+                "key": "ATG12D",
+                "name": "Democratic",
+                "sum": 3118591,
+                "min": 0,
+                "max": 2865
+              },
+              {
+                "key": "ATG12R",
+                "name": "Republican",
+                "sum": 2312801,
+                "min": 0,
+                "max": 2153
               }
             ]
           },
@@ -291,12 +451,18 @@
           }
         ],
         "idColumn": {
-          "name": "2020 Census GEOID",
+          "name": "VTD GEOID code",
           "key": "GEOID20"
         },
         "bounds": [
-          [-80.5199, 39.7198],
-          [-74.6896, 42.5161]
+          [
+            -80.5199,
+            39.7198
+          ],
+          [
+            -74.6896,
+            42.5161
+          ]
         ],
         "tilesets": [
           {
@@ -306,14 +472,6 @@
               "url": "mapbox://districtr.pa_vtds20"
             },
             "sourceLayer": "pa_vtds20"
-          },
-          {
-            "type": "circle",
-            "source": {
-              "type": "vector",
-              "url": "mapbox://districtr.pa_vtds20_points"
-            },
-            "sourceLayer": "pa_vtds20_points"
           }
         ]
       },

--- a/assets/data/modules/Utah.json
+++ b/assets/data/modules/Utah.json
@@ -199,11 +199,71 @@
         "unitType": "VTDs",
         "columnSets": [
           {
+            "type": "election",
+            "name": "2016 Presidential",
+            "subgroups": [
+              {
+                "key": "PRES16D",
+                "name": "Democratic",
+                "sum": 310695,
+                "min": 0,
+                "max": 1042
+              },
+              {
+                "key": "PRES16R",
+                "name": "Republican",
+                "sum": 515080,
+                "min": 0,
+                "max": 1190
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 US Senate",
+            "subgroups": [
+              {
+                "key": "SEN16D",
+                "name": "Democratic",
+                "sum": 301948,
+                "min": 0,
+                "max": 1025
+              },
+              {
+                "key": "SEN16R",
+                "name": "Republican",
+                "sum": 759491,
+                "min": 0,
+                "max": 1831
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 Governor",
+            "subgroups": [
+              {
+                "key": "GOV16D",
+                "name": "Democratic",
+                "sum": 323150,
+                "min": 0,
+                "max": 1067
+              },
+              {
+                "key": "GOV16R",
+                "name": "Republican",
+                "sum": 750893,
+                "min": 0,
+                "max": 1794
+              }
+            ]
+          },
+          {
             "type": "population",
             "name": "Population",
             "total": {
               "key": "TOTPOP",
-              "name": "Total Population",
+              "name": "Total population",
               "sum": 3271616,
               "min": 0,
               "max": 9881
@@ -224,11 +284,11 @@
                 "max": 471
               },
               {
-                "key": "AMIN",
-                "name": "American Indian population",
-                "sum": 28690,
+                "key": "HISP",
+                "name": "Hispanic population",
+                "sum": 492912,
                 "min": 0,
-                "max": 2318
+                "max": 2465
               },
               {
                 "key": "ASIAN",
@@ -238,18 +298,18 @@
                 "max": 618
               },
               {
+                "key": "AMIN",
+                "name": "American Indian population",
+                "sum": 28690,
+                "min": 0,
+                "max": 2318
+              },
+              {
                 "key": "NHPI",
-                "name": "Native Hawaiian and Pacific Islanders population",
+                "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 35831,
                 "min": 0,
                 "max": 602
-              },
-              {
-                "key": "OTHER",
-                "name": "Other races",
-                "sum": 12566,
-                "min": 0,
-                "max": 55
               },
               {
                 "key": "2MORE",
@@ -259,11 +319,11 @@
                 "max": 492
               },
               {
-                "key": "HISP",
-                "name": "Hispanic population",
-                "sum": 492912,
+                "key": "OTHER",
+                "name": "Other races",
+                "sum": 12566,
                 "min": 0,
-                "max": 2465
+                "max": 55
               }
             ]
           },
@@ -293,11 +353,25 @@
                 "max": 274
               },
               {
+                "key": "HVAP",
+                "name": "Hispanic voting age population",
+                "sum": 316610,
+                "min": 0,
+                "max": 1542
+              },
+              {
                 "key": "AMINVAP",
-                "name": "American Indian voting age population",
+                "name": "Native American voting age population",
                 "sum": 20985,
                 "min": 0,
                 "max": 1654
+              },
+              {
+                "key": "NHPIVAP",
+                "name": "Native Hawaiian and Pacific Islander voting age population",
+                "sum": 23424,
+                "min": 0,
+                "max": 362
               },
               {
                 "key": "ASIANVAP",
@@ -305,13 +379,6 @@
                 "sum": 62825,
                 "min": 0,
                 "max": 485
-              },
-              {
-                "key": "NHPIVAP",
-                "name": "Native Hawaiian and Pacific Islanders voting age population",
-                "sum": 23424,
-                "min": 0,
-                "max": 362
               },
               {
                 "key": "OTHERVAP",
@@ -326,24 +393,23 @@
                 "sum": 68249,
                 "min": 0,
                 "max": 327
-              },
-              {
-                "key": "HVAP",
-                "name": "Hispanic voting age population",
-                "sum": 316610,
-                "min": 0,
-                "max": 1542
               }
             ]
           }
         ],
         "idColumn": {
-          "name": "2020 Census GEOID",
+          "name": "VTD GEOID code",
           "key": "GEOID20"
         },
         "bounds": [
-          [-114.0529, 36.9977],
-          [-109.0416, 42.0017]
+          [
+            -114.0529,
+            36.9977
+          ],
+          [
+            -109.0416,
+            42.0017
+          ]
         ],
         "tilesets": [
           {

--- a/assets/data/modules/Virginia.json
+++ b/assets/data/modules/Virginia.json
@@ -199,11 +199,171 @@
         "unitType": "VTDs",
         "columnSets": [
           {
+            "type": "election",
+            "name": "2016 Presidential",
+            "subgroups": [
+              {
+                "key": "G16DPRS",
+                "name": "Democratic",
+                "sum": 1978974,
+                "min": 0,
+                "max": 3046
+              },
+              {
+                "key": "G16RPRS",
+                "name": "Republican",
+                "sum": 1768776,
+                "min": 0,
+                "max": 2912
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2016 US House",
+            "subgroups": [
+              {
+                "key": "G16DHOR",
+                "name": "Democratic",
+                "sum": 1857666,
+                "min": 0,
+                "max": 2806
+              },
+              {
+                "key": "G16RHOR",
+                "name": "Republican",
+                "sum": 1842056,
+                "min": 0,
+                "max": 3032
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2017 Governor",
+            "subgroups": [
+              {
+                "key": "G17DGOV",
+                "name": "Democratic",
+                "sum": 1407330,
+                "min": 0,
+                "max": 2324
+              },
+              {
+                "key": "G17RGOV",
+                "name": "Republican",
+                "sum": 1175494,
+                "min": 0,
+                "max": 1786
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2017 House of Delegates",
+            "subgroups": [
+              {
+                "key": "G17DHOD",
+                "name": "Democratic",
+                "sum": 1303186,
+                "min": 0,
+                "max": 2335
+              },
+              {
+                "key": "G17RHOD",
+                "name": "Republican",
+                "sum": 1075836,
+                "min": 0,
+                "max": 2030
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2017 Attorney General",
+            "subgroups": [
+              {
+                "key": "G17DATG",
+                "name": "Democratic",
+                "sum": 1384412,
+                "min": 0,
+                "max": 2289
+              },
+              {
+                "key": "G17RATG",
+                "name": "Republican",
+                "sum": 1209229,
+                "min": 0,
+                "max": 1867
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2017 Lt. Governor",
+            "subgroups": [
+              {
+                "key": "G17DLTG",
+                "name": "Democratic",
+                "sum": 1367409,
+                "min": 0,
+                "max": 2295
+              },
+              {
+                "key": "G17RLTG",
+                "name": "Republican",
+                "sum": 1224127,
+                "min": 0,
+                "max": 1869
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 US Senate",
+            "subgroups": [
+              {
+                "key": "G18DSEN",
+                "name": "Democratic",
+                "sum": 1908819,
+                "min": 0,
+                "max": 2772
+              },
+              {
+                "key": "G18RSEN",
+                "name": "Republican",
+                "sum": 1374046,
+                "min": 0,
+                "max": 2122
+              }
+            ]
+          },
+          {
+            "type": "election",
+            "name": "2018 US House",
+            "subgroups": [
+              {
+                "key": "G18DHOR",
+                "name": "Democratic",
+                "sum": 1865539,
+                "min": 0,
+                "max": 2725
+              },
+              {
+                "key": "G18RHOR",
+                "name": "Republican",
+                "sum": 1408373,
+                "min": 0,
+                "max": 2330
+              }
+            ]
+          },
+          {
             "type": "population",
             "name": "Population",
             "total": {
               "key": "TOTPOP",
-              "name": "Total Population",
+              "name": "Total population",
               "sum": 8631393,
               "min": 0,
               "max": 17815
@@ -224,11 +384,11 @@
                 "max": 5551
               },
               {
-                "key": "AMIN",
-                "name": "American Indian population",
-                "sum": 19080,
+                "key": "HISP",
+                "name": "Hispanic population",
+                "sum": 908749,
                 "min": 0,
-                "max": 306
+                "max": 5719
               },
               {
                 "key": "ASIAN",
@@ -238,18 +398,18 @@
                 "max": 5324
               },
               {
+                "key": "AMIN",
+                "name": "American Indian population",
+                "sum": 19080,
+                "min": 0,
+                "max": 306
+              },
+              {
                 "key": "NHPI",
-                "name": "Native Hawaiian and Pacific Islanders population",
+                "name": "Native Hawaiian and Pacific Islander population",
                 "sum": 6195,
                 "min": 0,
                 "max": 99
-              },
-              {
-                "key": "OTHER",
-                "name": "Other races",
-                "sum": 45394,
-                "min": 0,
-                "max": 224
               },
               {
                 "key": "2MORE",
@@ -259,11 +419,11 @@
                 "max": 918
               },
               {
-                "key": "HISP",
-                "name": "Hispanic population",
-                "sum": 908749,
+                "key": "OTHER",
+                "name": "Other races",
+                "sum": 45394,
                 "min": 0,
-                "max": 5719
+                "max": 224
               }
             ]
           },
@@ -293,11 +453,25 @@
                 "max": 4865
               },
               {
+                "key": "HVAP",
+                "name": "Hispanic voting age population",
+                "sum": 614314,
+                "min": 0,
+                "max": 3806
+              },
+              {
                 "key": "AMINVAP",
-                "name": "American Indian voting age population",
+                "name": "Native American voting age population",
                 "sum": 15376,
                 "min": 0,
                 "max": 274
+              },
+              {
+                "key": "NHPIVAP",
+                "name": "Native Hawaiian and Pacific Islander voting age population",
+                "sum": 4754,
+                "min": 0,
+                "max": 98
               },
               {
                 "key": "ASIANVAP",
@@ -305,13 +479,6 @@
                 "sum": 478337,
                 "min": 0,
                 "max": 4080
-              },
-              {
-                "key": "NHPIVAP",
-                "name": "Native Hawaiian and Pacific Islanders voting age population",
-                "sum": 4754,
-                "min": 0,
-                "max": 98
               },
               {
                 "key": "OTHERVAP",
@@ -326,144 +493,23 @@
                 "sum": 241069,
                 "min": 0,
                 "max": 781
-              },
-              {
-                "key": "HVAP",
-                "name": "Hispanic voting age population",
-                "sum": 614314,
-                "min": 0,
-                "max": 3806
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2016 Presidential",
-            "subgroups": [
-              {
-                "key": "G16RPRS",
-                "name": "Republican",
-                "sum": 1768776,
-                "min": 0,
-                "max": 2912
-              },
-              {
-                "key": "G16DPRS",
-                "name": "Democratic",
-                "sum": 1978974,
-                "min": 0,
-                "max": 3046
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2018 Senate",
-            "subgroups": [
-              {
-                "key": "G18RSEN",
-                "name": "Republican",
-                "sum": 1374046,
-                "min": 0,
-                "max": 2122
-              },
-              {
-                "key": "G18DSEN",
-                "name": "Democratic",
-                "sum": 1908819,
-                "min": 0,
-                "max": 2772
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2017 Lt. Governor",
-            "subgroups": [
-              {
-                "key": "G17RLTG",
-                "name": "Republican",
-                "sum": 1224127,
-                "min": 0,
-                "max": 1869
-              },
-              {
-                "key": "G17DLTG",
-                "name": "Democratic",
-                "sum": 1367409,
-                "min": 0,
-                "max": 2295
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2017 Attorney General",
-            "subgroups": [
-              {
-                "key": "G17RATG",
-                "name": "Republican",
-                "sum": 1209229,
-                "min": 0,
-                "max": 1867
-              },
-              {
-                "key": "G17DATG",
-                "name": "Democratic",
-                "sum": 1384412,
-                "min": 0,
-                "max": 2289
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2017 House of Delegates",
-            "subgroups": [
-              {
-                "key": "G17RHOD",
-                "name": "Republican",
-                "sum": 1075836,
-                "min": 0,
-                "max": 2030
-              },
-              {
-                "key": "G17DHOD",
-                "name": "Democratic",
-                "sum": 1303186,
-                "min": 0,
-                "max": 2335
-              }
-            ]
-          },
-          {
-            "type": "election",
-            "name": "2016 US House",
-            "subgroups": [
-              {
-                "key": "G16RHOR",
-                "name": "Republican",
-                "sum": 1842056,
-                "min": 0,
-                "max": 3032
-              },
-              {
-                "key": "G16DHOR",
-                "name": "Democratic",
-                "sum": 1857666,
-                "min": 0,
-                "max": 2806
               }
             ]
           }
         ],
         "idColumn": {
-          "name": "2020 Census GEOID",
+          "name": "VTD GEOID code",
           "key": "GEOID20"
         },
         "bounds": [
-          [-83.6754, 36.5409],
-          [-75.1664, 39.466]
+          [
+            -83.6754,
+            36.5409
+          ],
+          [
+            -75.1664,
+            39.466
+          ]
         ],
         "tilesets": [
           {


### PR DESCRIPTION
-affects 16 states (AL, AZ, CT, DE, IN, LA, MA, MN, NE, NH, NC, OH, OK, PA, UT, VA)
-in the case of AL, creates a new module. all others are updates to existing modules.
-makes election columns added on mapbox available in districtr modules