### PR TITLE
Fix dem/repub swap for Maryland's 2014 AG race

### DIFF
--- a/assets/data/modules/Maryland.json
+++ b/assets/data/modules/Maryland.json
@@ -405,14 +405,14 @@
             "subgroups": [
               {
                 "key": "AG14D",
-                "name": "Republican",
+                "name": "Democratic",
                 "sum": 934954,
                 "min": 0,
                 "max": 2040
               },
               {
                 "key": "AG14R",
-                "name": "Democratic",
+                "name": "Republican",
                 "sum": 681329,
                 "min": 0,
                 "max": 2900


### PR DESCRIPTION
Maryland's 2014 AG race has the dem/repub options accidently swapped. This patch fixes it.