### PR TITLE
fix event page draft plan bug (affecting Dallas event page)

### DIFF
--- a/src/views/event.js
+++ b/src/views/event.js
@@ -3180,7 +3180,7 @@ export default () => {
 
         fetch(eventurl).then(res => res.json()).then(showPlans);
         let drafturl = eventurl + (window.location.hostname === "localhost" ? "" : "&type=draft");
-        fetch(drafturl.replace(`limit=${limitNum + 1}`, "limit=0")).then(res => res.json()).then(p => showPlans(p, true))
+        fetch(drafturl.replace(`limit=${limitNum + 1}`, "limit=1")).then(res => res.json()).then(p => showPlans(p, true))
     } else {
         const target = document.getElementById("districting-options");
         render("Tag or Organization not recognized", target);


### PR DESCRIPTION
Change the limit on the initial draft plan fetch request from 0 to 1 to prevent event pages from attempting to fetch all draft plans upon loading. This was the source of a bug with the City of Dallas event page because the fetch response was exceeding the data limit (Dallas drafts have thumbnails). Event pages don't display any drafts upon loading anyway (even though they fetch them), and this fix does not affect how drafts are fetched after the initial loading of the page (i.e. the Load Drafts and Load More Drafts buttons function as intended).